### PR TITLE
fix(gateway): broadcast tool events to all WS clients for sub-agent visibility

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -330,7 +330,7 @@ export type AgentEventHandlerOptions = {
 
 export function createAgentEventHandler({
   broadcast,
-  broadcastToConnIds,
+  broadcastToConnIds: _broadcastToConnIds,
   nodeSendToSession,
   agentRunSeq,
   chatRunState,
@@ -575,14 +575,11 @@ export function createAgentEventHandler({
       if (toolPhase === "start" && isControlUiVisible && sessionKey && !isAborted) {
         flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
       }
-      // Always broadcast tool events to registered WS recipients with
-      // tool-events capability, regardless of verboseLevel. The verbose
-      // setting only controls whether tool details are sent as channel
-      // messages to messaging surfaces (Telegram, Discord, etc.).
-      const recipients = toolEventRecipients.get(evt.runId);
-      if (recipients && recipients.size > 0) {
-        broadcastToConnIds("agent", toolPayload, recipients);
-      }
+      // Broadcast tool events to all connected clients so sub-agent tool
+      // calls reach subscribed WS UIs (same delivery as non-tool events).
+      // The toolPayload already strips result/partialResult unless verbose=full.
+      // Frontend filters by sessionKey (only displays active/subscribed sessions).
+      broadcast("agent", toolPayload, { dropIfSlow: true });
     } else {
       broadcast("agent", agentPayload);
     }
@@ -592,7 +589,7 @@ export function createAgentEventHandler({
 
     if (isControlUiVisible && sessionKey) {
       // Send tool events to node/channel subscribers only when verbose is enabled;
-      // WS clients already received the event above via broadcastToConnIds.
+      // WS clients already received the event above via broadcast.
       if (!isToolEvent || toolVerbose !== "off") {
         nodeSendToSession(sessionKey, "agent", isToolEvent ? toolPayload : agentPayload);
       }


### PR DESCRIPTION
## Problem

Tool events in server-chat.ts were only delivered to WS clients registered in toolEventRecipients (via broadcastToConnIds). This registry is populated when a WS client sends chat.send, registering that client connection ID for tool events on that runId.

**Sub-agent runs are never registered** because they run autonomously without a chat.send from a WS client. Tool events for sub-agents were silently dropped.

## Fix

Changed tool event delivery from targeted (broadcastToConnIds) to broadcast — same delivery as non-tool events (thinking, lifecycle, assistant). Added dropIfSlow: true for backpressure protection.

## Why this is safe

1. Non-tool events already broadcast to ALL clients — this makes tool events consistent
2. toolPayload already strips result/partialResult unless verbose=full
3. Frontend filters tool events by session key (only displays active/subscribed sessions)
4. dropIfSlow: true prevents slow clients from blocking
5. toolEventRecipients registry still used for markFinal cleanup