### PR TITLE
feat: broadcast user messages to all WebSocket clients for multi-client sync

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1283,6 +1283,23 @@ export const chatHandlers: GatewayRequestHandlers = {
       };
       respond(true, ackPayload, undefined, { runId: clientRunId });
 
+      // Broadcast the user message to all connected WebSocket clients on
+      // this session so multi-client setups (e.g. phone + desktop) stay in
+      // sync. Without this, only the sending client sees the user message;
+      // other clients only receive assistant replies.
+      const userMessagePayload = {
+        runId: clientRunId,
+        sessionKey: rawSessionKey,
+        state: "user_message" as const,
+        message: {
+          role: "user" as const,
+          content: [{ type: "text" as const, text: parsedMessage }],
+          timestamp: now,
+        },
+      };
+      context.broadcast("chat", userMessagePayload);
+      context.nodeSendToSession(rawSessionKey, "chat", userMessagePayload);
+
       const trimmedMessage = parsedMessage.trim();
       const injectThinking = Boolean(
         p.thinking && trimmedMessage && !trimmedMessage.startsWith("/"),


### PR DESCRIPTION
## Problem

When multiple clients are connected to the same session (e.g. phone + desktop browser), user messages sent from one client don't appear on the other. The desktop only sees assistant replies, not user messages sent from the phone.

## Solution

Added a chat.user_message broadcast in the chat.send handler, immediately after the ack response. This follows the same broadcast() + nodeSendToSession() pattern already used for assistant messages.

### What this enables

- All connected WebSocket clients on the same session receive user messages in real time
- Frontend clients can listen for chat events with state user_message and add them to the chat UI
- The sending client already has the message locally; it can deduplicate by runId

## Testing

- Build passes (pnpm run build)
- Single file changed: src/gateway/server-methods/chat.ts (+17 lines)