### PR TITLE
fix(gateway): stream live agent events with explicit session keys

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -10,6 +10,7 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "compaction",
     data: { phase: "start" },
   });
@@ -63,6 +64,7 @@ export function handleAutoCompactionEnd(
   }
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "compaction",
     data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
   });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -18,6 +18,7 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "lifecycle",
     data: {
       phase: "start",
@@ -66,6 +67,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     });
     emitAgentEvent({
       runId: ctx.params.runId,
+      sessionKey: ctx.params.sessionKey,
       stream: "lifecycle",
       data: {
         phase: "error",
@@ -84,6 +86,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     ctx.log.debug(`embedded run agent end: runId=${ctx.params.runId} isError=${isError}`);
     emitAgentEvent({
       runId: ctx.params.runId,
+      sessionKey: ctx.params.sessionKey,
       stream: "lifecycle",
       data: {
         phase: "end",

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -246,6 +246,7 @@ export function handleMessageUpdate(
       });
       emitAgentEvent({
         runId: ctx.params.runId,
+        sessionKey: ctx.params.sessionKey,
         stream: "assistant",
         data,
       });
@@ -329,6 +330,7 @@ export function handleMessageEnd(
     });
     emitAgentEvent({
       runId: ctx.params.runId,
+      sessionKey: ctx.params.sessionKey,
       stream: "assistant",
       data,
     });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -340,6 +340,7 @@ export async function handleToolExecutionStart(
   const shouldEmitToolEvents = ctx.shouldEmitToolResult();
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "tool",
     data: {
       phase: "start",
@@ -401,6 +402,7 @@ export function handleToolExecutionUpdate(
   const sanitized = sanitizeToolResult(partial);
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "tool",
     data: {
       phase: "update",
@@ -520,6 +522,7 @@ export async function handleToolExecutionEnd(
 
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "tool",
     data: {
       phase: "result",

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { onAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
 import {
   THINKING_TAG_CASES,
   createStubSessionHarness,
@@ -12,6 +13,10 @@ import {
 import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
 
 describe("subscribeEmbeddedPiSession", () => {
+  afterEach(() => {
+    resetAgentEventsForTest();
+  });
+
   function createAgentEventHarness(options?: { runId?: string; sessionKey?: string }) {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();
@@ -106,7 +111,7 @@ describe("subscribeEmbeddedPiSession", () => {
 
   it.each(THINKING_TAG_CASES)(
     "streams <%s> reasoning via onReasoningStream without leaking into final text",
-    ({ open, close }) => {
+    async ({ open, close }) => {
       const onReasoningStream = vi.fn();
       const onBlockReply = vi.fn();
 
@@ -132,6 +137,7 @@ describe("subscribeEmbeddedPiSession", () => {
       } as AssistantMessage;
 
       emit({ type: "message_end", message: assistantMessage });
+      await Promise.resolve();
 
       expect(onBlockReply).toHaveBeenCalledTimes(1);
       expect(onBlockReply.mock.calls[0][0].text).toBe("Final answer");
@@ -149,7 +155,7 @@ describe("subscribeEmbeddedPiSession", () => {
   );
   it.each(THINKING_TAG_CASES)(
     "suppresses <%s> blocks across chunk boundaries",
-    ({ open, close }) => {
+    async ({ open, close }) => {
       const onBlockReply = vi.fn();
 
       const { emit } = createSubscribedHarness({
@@ -174,6 +180,7 @@ describe("subscribeEmbeddedPiSession", () => {
         message: { role: "assistant" },
         assistantMessageEvent: { type: "text_end" },
       });
+      await Promise.resolve();
 
       const payloadTexts = onBlockReply.mock.calls
         .map((call) => call[0]?.text)
@@ -227,6 +234,107 @@ describe("subscribeEmbeddedPiSession", () => {
       .filter((value): value is string => typeof value === "string");
     expect(streamTexts.at(-1)).toBe("Reasoning:\n_Checking files done_");
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits thinking agent events in stream mode even without onReasoningStream callback", () => {
+    resetAgentEventsForTest();
+    const seen: Array<{ stream?: string; sessionKey?: string; data?: Record<string, unknown> }> =
+      [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-thinking-no-callback") {
+        seen.push(evt);
+      }
+    });
+
+    try {
+      const { emit } = createSubscribedHarness({
+        runId: "run-thinking-no-callback",
+        reasoningMode: "stream",
+        sessionKey: "session-thinking",
+      });
+
+      emit({
+        type: "message_update",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "Checking files" }],
+        },
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          delta: "Checking files",
+        },
+      });
+
+      expect(seen).toContainEqual(
+        expect.objectContaining({
+          stream: "thinking",
+          sessionKey: "session-thinking",
+          data: expect.objectContaining({
+            text: "Reasoning:\n_Checking files_",
+            delta: "Reasoning:\n_Checking files_",
+          }),
+        }),
+      );
+    } finally {
+      stop();
+    }
+  });
+
+  it("emits explicit sessionKey on assistant/tool/compaction/lifecycle streams", async () => {
+    resetAgentEventsForTest();
+    const seen: Array<{ stream?: string; sessionKey?: string; data?: Record<string, unknown> }> =
+      [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-explicit-session-key") {
+        seen.push(evt);
+      }
+    });
+
+    try {
+      const { emit } = createSubscribedHarness({
+        runId: "run-explicit-session-key",
+        sessionKey: "session-explicit",
+      });
+
+      emit({ type: "agent_start" });
+      emit({ type: "message_start", message: { role: "assistant" } });
+      emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: { type: "text_delta", delta: "Hello" },
+      });
+      emit({
+        type: "tool_execution_start",
+        toolName: "read",
+        toolCallId: "tool-1",
+        args: { path: "/tmp/demo.txt" },
+      });
+      emit({ type: "auto_compaction_start" });
+      emit({ type: "auto_compaction_end", result: { ok: true } });
+      emit({ type: "agent_end" });
+      await Promise.resolve();
+
+      expect(
+        seen
+          .filter(
+            (evt) =>
+              evt.stream === "assistant" ||
+              evt.stream === "tool" ||
+              evt.stream === "compaction" ||
+              evt.stream === "lifecycle",
+          )
+          .map((evt) => ({ stream: evt.stream, sessionKey: evt.sessionKey })),
+      ).toEqual([
+        { stream: "lifecycle", sessionKey: "session-explicit" },
+        { stream: "assistant", sessionKey: "session-explicit" },
+        { stream: "tool", sessionKey: "session-explicit" },
+        { stream: "compaction", sessionKey: "session-explicit" },
+        { stream: "compaction", sessionKey: "session-explicit" },
+        { stream: "lifecycle", sessionKey: "session-explicit" },
+      ]);
+    } finally {
+      stop();
+    }
   });
 
   it("emits reasoning end once when native and tagged reasoning end overlap", () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -45,7 +45,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     reasoningMode,
     includeReasoning: reasoningMode === "on",
     shouldEmitPartialReplies: !(reasoningMode === "on" && !params.onBlockReply),
-    streamReasoning: reasoningMode === "stream" && typeof params.onReasoningStream === "function",
+    // Control UI consumes live thinking via agent events; do not require a
+    // separate onReasoningStream callback just to open the stream.
+    streamReasoning: reasoningMode === "stream",
     deltaBuffer: "",
     blockBuffer: "",
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
@@ -554,7 +556,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   const emitReasoningStream = (text: string) => {
-    if (!state.streamReasoning || !params.onReasoningStream) {
+    if (!state.streamReasoning) {
       return;
     }
     const formatted = formatReasoningMessage(text);
@@ -573,6 +575,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Broadcast thinking event to WebSocket clients in real-time
     emitAgentEvent({
       runId: params.runId,
+      sessionKey: params.sessionKey,
       stream: "thinking",
       data: {
         text: formatted,
@@ -580,7 +583,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       },
     });
 
-    void params.onReasoningStream({
+    void params.onReasoningStream?.({
       text: formatted,
     });
   };

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -876,6 +876,38 @@ describe("agent event handler", () => {
     expect(payload.sessionKey).toBe("session-from-event");
   });
 
+  it("uses explicit sessionKey on thinking events so webchat can filter live reasoning", () => {
+    const { broadcast, nodeSendToSession, handler } = createHarness({
+      resolveSessionKeyForRun: () => undefined,
+    });
+
+    handler({
+      runId: "run-thinking-session-key",
+      seq: 1,
+      stream: "thinking",
+      ts: 1_234,
+      sessionKey: "session-thinking",
+      data: {
+        text: "Reasoning:\n_Checking files_",
+        delta: "Reasoning:\n_Checking files_",
+      },
+    });
+
+    const payload = expectSingleAgentBroadcastPayload(broadcast);
+    expect(payload.sessionKey).toBe("session-thinking");
+    expect(payload.stream).toBe("thinking");
+
+    const nodeCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
+    expect(nodeCalls).toHaveLength(1);
+    expect(nodeCalls[0]?.[0]).toBe("session-thinking");
+    expect(nodeCalls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        stream: "thinking",
+        sessionKey: "session-thinking",
+      }),
+    );
+  });
+
   it("remaps chat-linked tool runId for non-full verbose payloads", () => {
     const { broadcastToConnIds, chatRunState, toolEventRecipients, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-tool-remap",


### PR DESCRIPTION
## Summary
- emit explicit `sessionKey` on embedded assistant/tool/lifecycle/compaction agent events so connected web clients can route them live
- emit `thinking` stream events in `reasoningMode: "stream"` even when no `onReasoningStream` callback is provided
- add regression coverage for live thinking/sessionKey routing through the gateway event fanout

## Fixes
- Fixes #9
- Fixes #11

## Exact blocker for #10
I could not truthfully include #10 in this PR: the dirty work I extracted does **not** contain an uncommitted delta for the queued `NO_REPLY` bubble bug.

The current tree already has `NO_REPLY` fallback logic in `src/agents/pi-embedded-subscribe.handlers.messages.ts`, but there was no additional dirty change tied to issue #10 to extract into this branch. So this PR is the clean handoff for the live event/feed fixes (#9 + #11), and #10 still needs either its missing diff recovered or a separate fix branch.

## Verification
- `git diff --check`
- attempted local commit hook / `pnpm check`, but it failed on an unrelated existing formatting problem in `src/gateway/server-methods/chat.ts` (not touched by this branch)
