### PR TITLE
feat(workflow): add agent event subscriptions for orchestration

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -79,6 +79,7 @@ public struct HelloOk: Codable, Sendable {
     public let _protocol: Int
     public let server: [String: AnyCodable]
     public let features: [String: AnyCodable]
+    public let caps: [String]?
     public let snapshot: Snapshot
     public let canvashosturl: String?
     public let auth: [String: AnyCodable]?
@@ -89,6 +90,7 @@ public struct HelloOk: Codable, Sendable {
         _protocol: Int,
         server: [String: AnyCodable],
         features: [String: AnyCodable],
+        caps: [String]?,
         snapshot: Snapshot,
         canvashosturl: String?,
         auth: [String: AnyCodable]?,
@@ -98,6 +100,7 @@ public struct HelloOk: Codable, Sendable {
         self._protocol = _protocol
         self.server = server
         self.features = features
+        self.caps = caps
         self.snapshot = snapshot
         self.canvashosturl = canvashosturl
         self.auth = auth
@@ -109,6 +112,7 @@ public struct HelloOk: Codable, Sendable {
         case _protocol = "protocol"
         case server
         case features
+        case caps
         case snapshot
         case canvashosturl = "canvasHostUrl"
         case auth
@@ -3704,6 +3708,76 @@ public struct ChatEvent: Codable, Sendable {
     }
 }
 
+public struct FileChunkParams: Codable, Sendable {
+    public let uploadid: String
+    public let chunkindex: Int
+    public let totalchunks: Int
+    public let data: String
+
+    public init(
+        uploadid: String,
+        chunkindex: Int,
+        totalchunks: Int,
+        data: String)
+    {
+        self.uploadid = uploadid
+        self.chunkindex = chunkindex
+        self.totalchunks = totalchunks
+        self.data = data
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case uploadid = "uploadId"
+        case chunkindex = "chunkIndex"
+        case totalchunks = "totalChunks"
+        case data
+    }
+}
+
+public struct FileCompleteParams: Codable, Sendable {
+    public let uploadid: String
+    public let filename: String
+    public let mimetype: String
+    public let totalsize: Int
+    public let sessionkey: String?
+
+    public init(
+        uploadid: String,
+        filename: String,
+        mimetype: String,
+        totalsize: Int,
+        sessionkey: String?)
+    {
+        self.uploadid = uploadid
+        self.filename = filename
+        self.mimetype = mimetype
+        self.totalsize = totalsize
+        self.sessionkey = sessionkey
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case uploadid = "uploadId"
+        case filename
+        case mimetype = "mimeType"
+        case totalsize = "totalSize"
+        case sessionkey = "sessionKey"
+    }
+}
+
+public struct FileCancelParams: Codable, Sendable {
+    public let uploadid: String
+
+    public init(
+        uploadid: String)
+    {
+        self.uploadid = uploadid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case uploadid = "uploadId"
+    }
+}
+
 public struct UpdateRunParams: Codable, Sendable {
     public let sessionkey: String?
     public let note: String?
@@ -3727,6 +3801,128 @@ public struct UpdateRunParams: Codable, Sendable {
         case note
         case restartdelayms = "restartDelayMs"
         case timeoutms = "timeoutMs"
+    }
+}
+
+public struct ChatTurnStartParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+
+    public init(
+        sessionkey: String,
+        turnid: String)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+    }
+}
+
+public struct ChatTurnAppendParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+    public let text: String
+    public let segmentindex: Int
+
+    public init(
+        sessionkey: String,
+        turnid: String,
+        text: String,
+        segmentindex: Int)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+        self.text = text
+        self.segmentindex = segmentindex
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+        case text
+        case segmentindex = "segmentIndex"
+    }
+}
+
+public struct ChatTurnUpdateParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+    public let kind: AnyCodable
+    public let ts: Int
+
+    public init(
+        sessionkey: String,
+        turnid: String,
+        kind: AnyCodable,
+        ts: Int)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+        self.kind = kind
+        self.ts = ts
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+        case kind
+        case ts
+    }
+}
+
+public struct ChatTurnCommitParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+    public let fulltext: String
+    public let segmentcount: Int
+    public let commitreason: String
+
+    public init(
+        sessionkey: String,
+        turnid: String,
+        fulltext: String,
+        segmentcount: Int,
+        commitreason: String)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+        self.fulltext = fulltext
+        self.segmentcount = segmentcount
+        self.commitreason = commitreason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+        case fulltext = "fullText"
+        case segmentcount = "segmentCount"
+        case commitreason = "commitReason"
+    }
+}
+
+public struct ChatTurnCancelParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+    public let reason: String
+
+    public init(
+        sessionkey: String,
+        turnid: String,
+        reason: String)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+        self.reason = reason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+        case reason
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -79,6 +79,7 @@ public struct HelloOk: Codable, Sendable {
     public let _protocol: Int
     public let server: [String: AnyCodable]
     public let features: [String: AnyCodable]
+    public let caps: [String]?
     public let snapshot: Snapshot
     public let canvashosturl: String?
     public let auth: [String: AnyCodable]?
@@ -89,6 +90,7 @@ public struct HelloOk: Codable, Sendable {
         _protocol: Int,
         server: [String: AnyCodable],
         features: [String: AnyCodable],
+        caps: [String]?,
         snapshot: Snapshot,
         canvashosturl: String?,
         auth: [String: AnyCodable]?,
@@ -98,6 +100,7 @@ public struct HelloOk: Codable, Sendable {
         self._protocol = _protocol
         self.server = server
         self.features = features
+        self.caps = caps
         self.snapshot = snapshot
         self.canvashosturl = canvashosturl
         self.auth = auth
@@ -109,6 +112,7 @@ public struct HelloOk: Codable, Sendable {
         case _protocol = "protocol"
         case server
         case features
+        case caps
         case snapshot
         case canvashosturl = "canvasHostUrl"
         case auth
@@ -3704,6 +3708,76 @@ public struct ChatEvent: Codable, Sendable {
     }
 }
 
+public struct FileChunkParams: Codable, Sendable {
+    public let uploadid: String
+    public let chunkindex: Int
+    public let totalchunks: Int
+    public let data: String
+
+    public init(
+        uploadid: String,
+        chunkindex: Int,
+        totalchunks: Int,
+        data: String)
+    {
+        self.uploadid = uploadid
+        self.chunkindex = chunkindex
+        self.totalchunks = totalchunks
+        self.data = data
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case uploadid = "uploadId"
+        case chunkindex = "chunkIndex"
+        case totalchunks = "totalChunks"
+        case data
+    }
+}
+
+public struct FileCompleteParams: Codable, Sendable {
+    public let uploadid: String
+    public let filename: String
+    public let mimetype: String
+    public let totalsize: Int
+    public let sessionkey: String?
+
+    public init(
+        uploadid: String,
+        filename: String,
+        mimetype: String,
+        totalsize: Int,
+        sessionkey: String?)
+    {
+        self.uploadid = uploadid
+        self.filename = filename
+        self.mimetype = mimetype
+        self.totalsize = totalsize
+        self.sessionkey = sessionkey
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case uploadid = "uploadId"
+        case filename
+        case mimetype = "mimeType"
+        case totalsize = "totalSize"
+        case sessionkey = "sessionKey"
+    }
+}
+
+public struct FileCancelParams: Codable, Sendable {
+    public let uploadid: String
+
+    public init(
+        uploadid: String)
+    {
+        self.uploadid = uploadid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case uploadid = "uploadId"
+    }
+}
+
 public struct UpdateRunParams: Codable, Sendable {
     public let sessionkey: String?
     public let note: String?
@@ -3727,6 +3801,128 @@ public struct UpdateRunParams: Codable, Sendable {
         case note
         case restartdelayms = "restartDelayMs"
         case timeoutms = "timeoutMs"
+    }
+}
+
+public struct ChatTurnStartParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+
+    public init(
+        sessionkey: String,
+        turnid: String)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+    }
+}
+
+public struct ChatTurnAppendParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+    public let text: String
+    public let segmentindex: Int
+
+    public init(
+        sessionkey: String,
+        turnid: String,
+        text: String,
+        segmentindex: Int)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+        self.text = text
+        self.segmentindex = segmentindex
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+        case text
+        case segmentindex = "segmentIndex"
+    }
+}
+
+public struct ChatTurnUpdateParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+    public let kind: AnyCodable
+    public let ts: Int
+
+    public init(
+        sessionkey: String,
+        turnid: String,
+        kind: AnyCodable,
+        ts: Int)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+        self.kind = kind
+        self.ts = ts
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+        case kind
+        case ts
+    }
+}
+
+public struct ChatTurnCommitParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+    public let fulltext: String
+    public let segmentcount: Int
+    public let commitreason: String
+
+    public init(
+        sessionkey: String,
+        turnid: String,
+        fulltext: String,
+        segmentcount: Int,
+        commitreason: String)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+        self.fulltext = fulltext
+        self.segmentcount = segmentcount
+        self.commitreason = commitreason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+        case fulltext = "fullText"
+        case segmentcount = "segmentCount"
+        case commitreason = "commitReason"
+    }
+}
+
+public struct ChatTurnCancelParams: Codable, Sendable {
+    public let sessionkey: String
+    public let turnid: String
+    public let reason: String
+
+    public init(
+        sessionkey: String,
+        turnid: String,
+        reason: String)
+    {
+        self.sessionkey = sessionkey
+        self.turnid = turnid
+        self.reason = reason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionkey = "sessionKey"
+        case turnid = "turnId"
+        case reason
     }
 }
 

--- a/docs/workflow-events.md
+++ b/docs/workflow-events.md
@@ -1,0 +1,280 @@
+# Workflow Events
+
+OpenClaw gateway v1 ships an optional workflow event subscription model for
+orchestration. It is **fully backward-compatible**: clients that do not call
+`workflow.subscribe` receive no new events and existing behavior is unchanged.
+
+---
+
+## Overview
+
+A process-global in-memory broker (`src/infra/workflow-events.ts`) emits a
+stable `WorkflowEvent` envelope whenever key orchestration lifecycle changes
+occur. The gateway exposes `workflow.subscribe` / `workflow.unsubscribe`
+methods so WebSocket clients can opt in. Events are delivered as
+`workflow.event` server frames to subscribed connections only.
+
+### Event kinds
+
+| Kind                 | When emitted                                             |
+| -------------------- | -------------------------------------------------------- |
+| `run.started`        | An agent run begins (`lifecycle` phase=start)            |
+| `run.completed`      | A run ends successfully (`lifecycle` phase=end)          |
+| `run.failed`         | A run ends with error (`lifecycle` phase=error)          |
+| `subagent.spawned`   | A subagent is registered (before it starts running)      |
+| `subagent.completed` | A subagent finishes with ok/killed/reset/deleted outcome |
+| `subagent.failed`    | A subagent finishes with error/timeout outcome           |
+
+### WorkflowEvent envelope
+
+```ts
+type WorkflowEvent = {
+  id: string; // UUID, stable identifier for this event
+  cursor: number; // Monotonically increasing integer (global, per gateway process)
+  kind: WorkflowEventKind;
+  ts: number; // Unix ms timestamp
+  sessionKey?: string; // Session that owns/triggered this event
+  runId?: string; // Agent run ID
+  parentSessionKey?: string; // For subagent.* events: the spawning session
+  childSessionKey?: string; // For subagent.* events: the spawned session
+  data: Record<string, unknown>; // Kind-specific fields
+};
+```
+
+---
+
+## Gateway API
+
+### `workflow.subscribe`
+
+Register (or replace) a workflow event subscription for this connection.
+
+**Request:**
+
+```json
+{
+  "type": "request",
+  "method": "workflow.subscribe",
+  "id": "req-1",
+  "params": {
+    "afterCursor": 0,
+    "kinds": ["subagent.spawned", "subagent.completed", "subagent.failed"],
+    "sessionKey": "agent:my-agent"
+  }
+}
+```
+
+| Field         | Type                  | Description                                                                                               |
+| ------------- | --------------------- | --------------------------------------------------------------------------------------------------------- |
+| `afterCursor` | `number` (optional)   | Replay buffered events emitted after this cursor. Pass `0` (or omit) to skip replay.                      |
+| `kinds`       | `string[]` (optional) | Only deliver events matching these kinds. Omit to receive all kinds.                                      |
+| `sessionKey`  | `string` (optional)   | Only deliver events associated with this session (parentSessionKey / childSessionKey / sessionKey match). |
+
+**Response:**
+
+```json
+{
+  "type": "response",
+  "id": "req-1",
+  "result": {
+    "subscribed": true,
+    "bufferHead": 42,
+    "oldestCursor": 1,
+    "replayed": [...]
+  }
+}
+```
+
+| Field          | Description                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `subscribed`   | `true` on success                                                                         |
+| `bufferHead`   | Cursor of the most recent event in the replay buffer                                      |
+| `oldestCursor` | Oldest cursor in the buffer; if `afterCursor` < `oldestCursor`, events were evicted (gap) |
+| `replayed`     | Array of `WorkflowEvent` objects emitted after `afterCursor`                              |
+
+### `workflow.unsubscribe`
+
+Remove the workflow subscription for this connection.
+
+**Request:**
+
+```json
+{
+  "type": "request",
+  "method": "workflow.unsubscribe",
+  "id": "req-2",
+  "params": {}
+}
+```
+
+### `workflow.event` (server event)
+
+Delivered to subscribed connections only when a matching event is emitted.
+
+```json
+{
+  "type": "event",
+  "event": "workflow.event",
+  "payload": {
+    "id": "e1a2b3...",
+    "cursor": 7,
+    "kind": "subagent.completed",
+    "ts": 1711234567890,
+    "sessionKey": "agent:orchestrator",
+    "parentSessionKey": "agent:orchestrator",
+    "childSessionKey": "agent:sub-task-1",
+    "runId": "run-abc123",
+    "data": { "outcome": "ok", "reason": "subagent-complete" }
+  }
+}
+```
+
+---
+
+## Replay and gap detection
+
+The broker maintains an in-memory ring buffer of the last 500 events. On
+reconnect, clients should:
+
+1. Call `workflow.subscribe` with `afterCursor` set to the last cursor they
+   saw before disconnect.
+2. Inspect the response:
+   - If `afterCursor >= oldestCursor`: replay is complete, no gap.
+   - If `afterCursor < oldestCursor`: events were evicted. Treat this as a
+     gap and do a full refresh (e.g., re-fetch session state via
+     `sessions.list`).
+
+---
+
+## Talkyn / client integration guide
+
+### Feature detection
+
+Before subscribing, detect support by checking the `methods` array in the
+`hello-ok` response (or the gateway's method list):
+
+```ts
+function supportsWorkflowEvents(methods: string[]): boolean {
+  return methods.includes("workflow.subscribe");
+}
+```
+
+### Recommended integration
+
+```ts
+// On connect, after hello-ok received:
+if (supportsWorkflowEvents(helloOk.methods)) {
+  ws.send(
+    JSON.stringify({
+      type: "request",
+      method: "workflow.subscribe",
+      id: "wf-sub-1",
+      params: {
+        afterCursor: lastSeenCursor ?? 0,
+        kinds: ["subagent.spawned", "subagent.completed", "subagent.failed"],
+      },
+    }),
+  );
+}
+
+// Handle incoming events:
+ws.on("message", (raw) => {
+  const frame = JSON.parse(raw);
+  if (frame.type === "event" && frame.event === "workflow.event") {
+    handleWorkflowEvent(frame.payload);
+    lastSeenCursor = frame.payload.cursor;
+  }
+  // Existing session.message / sessions.changed handlers are unchanged.
+});
+```
+
+### Graceful fallback
+
+When the gateway does not support workflow events (native/upstream OpenClaw
+or an older fork version), `workflow.subscribe` will return a
+`METHOD_NOT_FOUND` error or the method will be absent from `methods`.
+
+In this case, fall back to the existing polling strategy:
+
+- Listen for `sessions.changed` events to detect session state changes.
+- Listen for `session.message` events for individual message delivery.
+- Poll session state via `sessions.list` as needed.
+
+This fallback ensures Talkyn continues to work against upstream/native
+OpenClaw without fork-only dependencies.
+
+```ts
+ws.on("message", (raw) => {
+  const frame = JSON.parse(raw);
+  if (frame.type === "response" && frame.id === "wf-sub-1") {
+    if (!frame.result?.subscribed) {
+      // Workflow events not supported; activate fallback polling.
+      activateLegacySessionPolling();
+    }
+  }
+});
+```
+
+---
+
+## Session-level wait/wake (`workflow_wait` tool)
+
+Orchestrator agents can use the `workflow_wait` tool to pause their current
+turn until a matching workflow event is emitted. This is built on the same
+broker and respects self-wake guards.
+
+**Tool name:** `workflow_wait`
+
+**Parameters:**
+
+| Param         | Type                                 | Description                        |
+| ------------- | ------------------------------------ | ---------------------------------- |
+| `kinds`       | `string[]` (optional)                | Event kinds to wait for            |
+| `session_key` | `string` (optional)                  | Only match events for this session |
+| `timeout_ms`  | `number` (optional, default 120 000) | Timeout in ms                      |
+
+**Example:**
+
+```
+workflow_wait({"kinds": ["subagent.completed"], "session_key": "agent:sub-task-1", "timeout_ms": 60000})
+```
+
+Returns:
+
+- `{ status: "matched", event: WorkflowEvent }` on success
+- `{ status: "timeout", error: "..." }` on timeout
+
+The tool does not self-wake: events emitted by the same orchestrator session
+during the same turn are ignored as waiter matches.
+
+---
+
+## Architecture
+
+```
+onAgentEvent (infra/agent-events.ts)
+  └─ workflow-event-bridge.ts          maps lifecycle events → run.*
+       └─ emitWorkflowEvent()
+            ├─ replay buffer (ring, 500 events)
+            ├─ per-connection subscriber callbacks
+            │    └─ broadcastToConnIds("workflow.event", ...)
+            └─ one-shot waiters (workflow_wait tool)
+
+subagent-registry.ts
+  ├─ registerSubagentRun → emitSubagentWorkflowEvent("subagent.spawned")
+  └─ emitSubagentEndedHookForRun → emitSubagentWorkflowEvent("subagent.completed"|"subagent.failed")
+```
+
+---
+
+## v1 limitations and follow-ups
+
+- Replay buffer is in-memory only; events are lost on gateway restart. Clients
+  should always use gap detection and fall back to `sessions.list` on reconnect.
+- The broker is process-global (singleton); multi-process gateway deployments
+  would need a shared bus (out of scope for v1).
+- The `workflow_wait` tool does not persist across session restarts; if the
+  gateway restarts while a tool is waiting, the session will receive a timeout
+  error on next wake.
+- Filter matching on `sessionKey` is a simple equality check; glob/pattern
+  matching is not supported in v1.

--- a/src/agents/internal-events.ts
+++ b/src/agents/internal-events.ts
@@ -1,4 +1,4 @@
-export type AgentInternalEventType = "task_completion";
+export type AgentInternalEventType = "task_completion" | "workflow_event";
 
 export type AgentTaskCompletionInternalEvent = {
   type: "task_completion";
@@ -14,7 +14,26 @@ export type AgentTaskCompletionInternalEvent = {
   replyInstruction: string;
 };
 
-export type AgentInternalEvent = AgentTaskCompletionInternalEvent;
+/**
+ * Injected into an orchestrator turn when a workflow_wait resolves.
+ * The orchestrator receives this as runtime context so it can inspect
+ * the matched event and continue from where it yielded.
+ */
+export type AgentWorkflowEventInternalEvent = {
+  type: "workflow_event";
+  /** Stable workflow event id. */
+  eventId: string;
+  /** Workflow event kind (e.g. "subagent.completed"). */
+  kind: string;
+  ts: number;
+  sessionKey?: string;
+  runId?: string;
+  parentSessionKey?: string;
+  childSessionKey?: string;
+  data: Record<string, unknown>;
+};
+
+export type AgentInternalEvent = AgentTaskCompletionInternalEvent | AgentWorkflowEventInternalEvent;
 
 function formatTaskCompletionEvent(event: AgentTaskCompletionInternalEvent): string {
   const lines = [
@@ -38,6 +57,36 @@ function formatTaskCompletionEvent(event: AgentTaskCompletionInternalEvent): str
   return lines.join("\n");
 }
 
+function formatWorkflowEventInternalEvent(event: AgentWorkflowEventInternalEvent): string {
+  const lines = [
+    "[Internal workflow event]",
+    `event_id: ${event.eventId}`,
+    `kind: ${event.kind}`,
+    `ts: ${event.ts}`,
+  ];
+  if (event.sessionKey) {
+    lines.push(`session_key: ${event.sessionKey}`);
+  }
+  if (event.runId) {
+    lines.push(`run_id: ${event.runId}`);
+  }
+  if (event.parentSessionKey) {
+    lines.push(`parent_session_key: ${event.parentSessionKey}`);
+  }
+  if (event.childSessionKey) {
+    lines.push(`child_session_key: ${event.childSessionKey}`);
+  }
+  if (event.data && Object.keys(event.data).length > 0) {
+    lines.push(`data: ${JSON.stringify(event.data)}`);
+  }
+  lines.push(
+    "",
+    "Action:",
+    "The workflow_wait call has resolved. Resume your orchestration from the point you yielded.",
+  );
+  return lines.join("\n");
+}
+
 export function formatAgentInternalEventsForPrompt(events?: AgentInternalEvent[]): string {
   if (!events || events.length === 0) {
     return "";
@@ -46,6 +95,9 @@ export function formatAgentInternalEventsForPrompt(events?: AgentInternalEvent[]
     .map((event) => {
       if (event.type === "task_completion") {
         return formatTaskCompletionEvent(event);
+      }
+      if (event.type === "workflow_event") {
+        return formatWorkflowEventInternalEvent(event);
       }
       return "";
     })

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -26,6 +26,7 @@ import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
 import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
+import { createWorkflowWaitTool } from "./tools/workflow-wait-tool.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 export function createOpenClawTools(
@@ -200,6 +201,11 @@ export function createOpenClawTools(
     createSessionsYieldTool({
       sessionId: options?.sessionId,
       onYield: options?.onYield,
+    }),
+    createWorkflowWaitTool({
+      callerSessionKey: options?.agentSessionKey,
+      onYield: options?.onYield,
+      config: options?.config,
     }),
     createSessionsSpawnTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -14,6 +14,7 @@ import { resolveContextEngine } from "../context-engine/registry.js";
 import type { SubagentEndReason } from "../context-engine/types.js";
 import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
+import { emitSubagentWorkflowEvent } from "../infra/workflow-event-bridge.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { defaultRuntime } from "../runtime.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
@@ -439,6 +440,18 @@ async function emitSubagentEndedHookForRun(params: {
   const reason = params.reason ?? params.entry.endedReason ?? SUBAGENT_ENDED_REASON_COMPLETE;
   const outcome = resolveLifecycleOutcomeFromRunOutcome(params.entry.outcome);
   const error = params.entry.outcome?.status === "error" ? params.entry.outcome.error : undefined;
+  // Emit workflow event for orchestration subscribers.
+  const wfKind =
+    outcome === "ok" || outcome === "killed" || outcome === "reset" || outcome === "deleted"
+      ? ("subagent.completed" as const)
+      : ("subagent.failed" as const);
+  emitSubagentWorkflowEvent({
+    kind: wfKind,
+    runId: params.entry.runId,
+    parentSessionKey: params.entry.requesterSessionKey,
+    childSessionKey: params.entry.childSessionKey,
+    data: { outcome, reason, error },
+  });
   await emitSubagentEndedHookOnce({
     entry: params.entry,
     reason,
@@ -1397,6 +1410,14 @@ export function registerSubagentRun(params: {
   if (archiveAtMs) {
     startSweeper();
   }
+  // Emit workflow event for orchestration subscribers.
+  emitSubagentWorkflowEvent({
+    kind: "subagent.spawned",
+    runId: params.runId,
+    parentSessionKey: params.requesterSessionKey,
+    childSessionKey: params.childSessionKey,
+    data: { label: params.label, task: params.task, spawnMode },
+  });
   // Wait for subagent completion via gateway RPC (cross-process).
   // The in-process lifecycle listener is a fallback for embedded runs.
   void waitForSubagentCompletion(params.runId, waitTimeoutMs);

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -154,6 +154,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "workflow_wait",
+    label: "workflow_wait",
+    description: "Yield turn and resume when a workflow event fires",
+    sectionId: "sessions",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "subagents",
     label: "subagents",
     description: "Manage sub-agents",

--- a/src/agents/tools/workflow-wait-tool.ts
+++ b/src/agents/tools/workflow-wait-tool.ts
@@ -1,0 +1,193 @@
+/**
+ * workflow_wait tool: pause the current orchestrator session turn until a
+ * matching workflow event is emitted, or a timeout expires.
+ *
+ * ## Yield-then-wake pattern (orchestrator context)
+ *
+ * When `onYield` is provided (orchestrator turn with a yield mechanism):
+ *   1. A one-shot waiter is registered in the broker.
+ *   2. The current turn is ended immediately via `onYield` (like sessions_yield).
+ *   3. When a matching event fires, the session is woken via a new gateway
+ *      "agent" request carrying a `workflow_event` internalEvent so the
+ *      orchestrator resumes with full event context.
+ *
+ * ## Blocking fallback (non-orchestrator context)
+ *
+ * When `onYield` is not provided, the tool falls back to awaiting the promise
+ * directly. This is suitable for short-lived test or scripted contexts where
+ * the session lock is not a concern.
+ *
+ * ## Self-wake guard
+ *
+ * If `callerSessionKey` is provided, events that originate from that session
+ * are not considered as matches. This prevents an orchestrator from waking
+ * itself on its own subagent.spawned event (which fires in the same turn).
+ */
+
+import { randomUUID } from "node:crypto";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "../../config/config.js";
+import { callGateway } from "../../gateway/call.js";
+import {
+  clearWorkflowWaitersForSession,
+  waitForWorkflowEvent,
+  type WorkflowEventKind,
+} from "../../infra/workflow-events.js";
+import type { AgentWorkflowEventInternalEvent } from "../internal-events.js";
+import { formatAgentInternalEventsForPrompt } from "../internal-events.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+
+const VALID_KINDS: WorkflowEventKind[] = [
+  "run.started",
+  "run.completed",
+  "run.failed",
+  "subagent.spawned",
+  "subagent.completed",
+  "subagent.failed",
+];
+
+const WorkflowWaitToolSchema = Type.Object({
+  /** Which event kinds to wait for. Omit or leave empty to accept any kind. */
+  kinds: Type.Optional(
+    Type.Array(
+      Type.String({
+        enum: VALID_KINDS,
+      }),
+    ),
+  ),
+  /**
+   * Only match events associated with this session key (parentSessionKey,
+   * childSessionKey, or sessionKey field on the event).
+   */
+  session_key: Type.Optional(Type.String()),
+  /**
+   * Maximum wait time in milliseconds. Defaults to 120 000 (2 minutes).
+   * Use 0 to disable timeout (not recommended for production orchestrators).
+   */
+  timeout_ms: Type.Optional(Type.Integer({ minimum: 0 })),
+});
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export function createWorkflowWaitTool(opts?: {
+  /** Session key of the calling orchestrator (used for self-wake guard and as wake target). */
+  callerSessionKey?: string;
+  /** Callback to end the current orchestrator turn (required for yield-then-wake). */
+  onYield?: (message: string) => Promise<void> | void;
+  /** Config for gateway calls (used when waking the session after event fires). */
+  config?: OpenClawConfig;
+}): AnyAgentTool {
+  return {
+    label: "Wait for workflow event",
+    name: "workflow_wait",
+    description:
+      "End this agent turn and resume later when a matching workflow event fires (e.g. subagent.completed), or fall back to blocking if no yield mechanism is available. Returns the matched event or a timeout error.",
+    parameters: WorkflowWaitToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+
+      const kindsRaw = Array.isArray(params.kinds) ? (params.kinds as string[]) : [];
+      const kinds = kindsRaw.filter((k): k is WorkflowEventKind =>
+        (VALID_KINDS as string[]).includes(k),
+      );
+
+      const sessionKey = readStringParam(params, "session_key") || undefined;
+      const timeoutMs =
+        typeof params.timeout_ms === "number" && params.timeout_ms >= 0
+          ? params.timeout_ms
+          : DEFAULT_TIMEOUT_MS;
+
+      const filter = {
+        kinds: kinds.length > 0 ? kinds : undefined,
+        sessionKey,
+      };
+
+      // --- Yield-then-wake path (preferred, orchestrator context) ---
+      if (opts?.onYield && opts?.callerSessionKey) {
+        const callerKey = opts.callerSessionKey;
+        const config = opts.config;
+
+        // Register the waiter as a background promise — do NOT await it.
+        const eventPromise = waitForWorkflowEvent(filter, timeoutMs, callerKey);
+
+        // When the event fires, wake the session with a workflow_event internalEvent.
+        eventPromise
+          .then(async (evt) => {
+            const internalEvent: AgentWorkflowEventInternalEvent = {
+              type: "workflow_event",
+              eventId: evt.id,
+              kind: evt.kind,
+              ts: evt.ts,
+              sessionKey: evt.sessionKey,
+              runId: evt.runId,
+              parentSessionKey: evt.parentSessionKey,
+              childSessionKey: evt.childSessionKey,
+              data: evt.data,
+            };
+            const message = formatAgentInternalEventsForPrompt([internalEvent]);
+            await callGateway({
+              method: "agent",
+              params: {
+                sessionKey: callerKey,
+                message,
+                internalEvents: [internalEvent],
+                deliver: false,
+                idempotencyKey: `workflow_wake:${evt.id}:${callerKey}`,
+              },
+              config,
+            });
+          })
+          .catch(() => {
+            // Timeout or cancelled — session stays idle until the next external message.
+          });
+
+        // End the current turn immediately, like sessions_yield.
+        await opts.onYield("Waiting for workflow event…");
+        return jsonResult({
+          status: "yielded",
+          message: "Turn ended. Session will resume when a matching workflow event arrives.",
+        });
+      }
+
+      // --- Blocking fallback (non-orchestrator or test context) ---
+      try {
+        const evt = await waitForWorkflowEvent(filter, timeoutMs, opts?.callerSessionKey);
+        return jsonResult({
+          status: "matched",
+          event: {
+            id: evt.id,
+            cursor: evt.cursor,
+            kind: evt.kind,
+            ts: evt.ts,
+            sessionKey: evt.sessionKey,
+            runId: evt.runId,
+            parentSessionKey: evt.parentSessionKey,
+            childSessionKey: evt.childSessionKey,
+            data: evt.data,
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult({ status: "timeout", error: message });
+      }
+    },
+  };
+}
+
+/**
+ * Cancel all pending workflow_wait calls for a session (call on teardown).
+ * Delegates to the broker's waiter cleanup.
+ */
+export { clearWorkflowWaitersForSession };
+
+/** Generate a stable idempotency key for a workflow wake call (exported for tests). */
+export function buildWorkflowWakeIdempotencyKey(eventId: string, sessionKey: string): string {
+  return `workflow_wake:${eventId}:${sessionKey}`;
+}
+
+// Re-export the kinds list for use in tests/configuration.
+export const WORKFLOW_WAIT_VALID_KINDS: readonly WorkflowEventKind[] = VALID_KINDS;
+
+/** Unique waiter id generator (exported for tests). */
+export { randomUUID as _generateWaiterId };

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -73,6 +73,8 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "sessions.unsubscribe",
     "sessions.messages.subscribe",
     "sessions.messages.unsubscribe",
+    "workflow.subscribe",
+    "workflow.unsubscribe",
     "sessions.usage",
     "sessions.usage.timeseries",
     "sessions.usage.logs",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -278,6 +278,10 @@ import {
   ChatTurnCommitParamsSchema,
   type ChatTurnCancelParams,
   ChatTurnCancelParamsSchema,
+  WorkflowSubscribeParamsSchema,
+  WorkflowUnsubscribeParamsSchema,
+  type WorkflowSubscribeParams,
+  type WorkflowUnsubscribeParams,
 } from "./schema.js";
 
 const ajv = new (AjvPkg as unknown as new (opts?: object) => import("ajv").default)({
@@ -479,6 +483,12 @@ export const validateChatTurnCommitParams = ajv.compile<ChatTurnCommitParams>(
 );
 export const validateChatTurnCancelParams = ajv.compile<ChatTurnCancelParams>(
   ChatTurnCancelParamsSchema,
+);
+export const validateWorkflowSubscribeParams = ajv.compile<WorkflowSubscribeParams>(
+  WorkflowSubscribeParamsSchema,
+);
+export const validateWorkflowUnsubscribeParams = ajv.compile<WorkflowUnsubscribeParams>(
+  WorkflowUnsubscribeParamsSchema,
 );
 
 export function formatValidationErrors(errors: ErrorObject[] | null | undefined) {
@@ -753,4 +763,6 @@ export type {
   FileChunkParams,
   FileCompleteParams,
   FileCancelParams,
+  WorkflowSubscribeParams,
+  WorkflowUnsubscribeParams,
 };

--- a/src/gateway/protocol/schema.ts
+++ b/src/gateway/protocol/schema.ts
@@ -17,3 +17,4 @@ export * from "./schema/snapshot.js";
 export * from "./schema/types.js";
 export * from "./schema/voice-turns.js";
 export * from "./schema/wizard.js";
+export * from "./schema/workflow.js";

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -1,22 +1,34 @@
 import { Type } from "@sinclair/typebox";
 import { InputProvenanceSchema, NonEmptyString, SessionLabelString } from "./primitives.js";
 
-export const AgentInternalEventSchema = Type.Object(
-  {
-    type: Type.Literal("task_completion"),
-    source: Type.String({ enum: ["subagent", "cron"] }),
-    childSessionKey: Type.String(),
-    childSessionId: Type.Optional(Type.String()),
-    announceType: Type.String(),
-    taskLabel: Type.String(),
-    status: Type.String({ enum: ["ok", "timeout", "error", "unknown"] }),
-    statusLabel: Type.String(),
-    result: Type.String(),
-    statsLine: Type.Optional(Type.String()),
-    replyInstruction: Type.String(),
-  },
-  { additionalProperties: false },
-);
+/**
+ * Internal event schema for internalEvents array on agent requests.
+ * Supports two types: "task_completion" (subagent/cron wake) and
+ * "workflow_event" (workflow_wait resolution). Fields for each type are
+ * optional here so both shapes can coexist in one object schema.
+ */
+export const AgentInternalEventSchema = Type.Object({
+  type: Type.String({ enum: ["task_completion", "workflow_event"] }),
+  // task_completion fields
+  source: Type.Optional(Type.String({ enum: ["subagent", "cron"] })),
+  childSessionKey: Type.Optional(Type.String()),
+  childSessionId: Type.Optional(Type.String()),
+  announceType: Type.Optional(Type.String()),
+  taskLabel: Type.Optional(Type.String()),
+  status: Type.Optional(Type.String({ enum: ["ok", "timeout", "error", "unknown"] })),
+  statusLabel: Type.Optional(Type.String()),
+  result: Type.Optional(Type.String()),
+  statsLine: Type.Optional(Type.String()),
+  replyInstruction: Type.Optional(Type.String()),
+  // workflow_event fields
+  eventId: Type.Optional(Type.String()),
+  kind: Type.Optional(Type.String()),
+  ts: Type.Optional(Type.Integer({ minimum: 0 })),
+  sessionKey: Type.Optional(Type.String()),
+  runId: Type.Optional(Type.String()),
+  parentSessionKey: Type.Optional(Type.String()),
+  data: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
 
 export const AgentEventSchema = Type.Object(
   {

--- a/src/gateway/protocol/schema/workflow.ts
+++ b/src/gateway/protocol/schema/workflow.ts
@@ -1,0 +1,76 @@
+import { Type } from "@sinclair/typebox";
+
+/**
+ * Params for workflow.subscribe.
+ *
+ * The client may repeat this call to replace its active filter for the
+ * connection. Repeated subscribe replaces the previous subscription.
+ */
+export const WorkflowSubscribeParamsSchema = Type.Object(
+  {
+    /**
+     * Optional cursor: replay buffered events emitted after this cursor value.
+     * Pass 0 (or omit) to receive only new events from this point forward.
+     * The response includes `bufferHead` and `oldestCursor` so the client can
+     * detect whether a gap has occurred and decide to do a full refresh.
+     */
+    afterCursor: Type.Optional(Type.Integer({ minimum: 0 })),
+    /** If set, only deliver events matching these kinds. */
+    kinds: Type.Optional(
+      Type.Array(
+        Type.String({
+          enum: [
+            "run.started",
+            "run.completed",
+            "run.failed",
+            "subagent.spawned",
+            "subagent.completed",
+            "subagent.failed",
+          ],
+        }),
+        { minItems: 1 },
+      ),
+    ),
+    /** If set, only deliver events associated with this session key. */
+    sessionKey: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+/** Params for workflow.unsubscribe. */
+export const WorkflowUnsubscribeParamsSchema = Type.Object({}, { additionalProperties: false });
+
+/**
+ * Shape of the `workflow.event` server-sent event payload.
+ * Mirrors WorkflowEvent from the broker.
+ */
+export const WorkflowEventPayloadSchema = Type.Object(
+  {
+    id: Type.String(),
+    cursor: Type.Integer({ minimum: 1 }),
+    kind: Type.String(),
+    ts: Type.Integer({ minimum: 0 }),
+    sessionKey: Type.Optional(Type.String()),
+    runId: Type.Optional(Type.String()),
+    parentSessionKey: Type.Optional(Type.String()),
+    childSessionKey: Type.Optional(Type.String()),
+    data: Type.Record(Type.String(), Type.Unknown()),
+  },
+  { additionalProperties: false },
+);
+
+export type WorkflowSubscribeKind =
+  | "run.started"
+  | "run.completed"
+  | "run.failed"
+  | "subagent.spawned"
+  | "subagent.completed"
+  | "subagent.failed";
+
+export type WorkflowSubscribeParams = {
+  afterCursor?: number;
+  kinds?: WorkflowSubscribeKind[];
+  sessionKey?: string;
+};
+
+export type WorkflowUnsubscribeParams = Record<string, never>;

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -454,7 +454,7 @@ export type AgentEventHandlerOptions = {
 
 export function createAgentEventHandler({
   broadcast,
-  broadcastToConnIds: _broadcastToConnIds,
+  broadcastToConnIds,
   nodeSendToSession,
   agentRunSeq,
   chatRunState,

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -121,6 +121,9 @@ const BASE_METHODS = [
   "file.chunk",
   "file.complete",
   "file.cancel",
+  // Workflow event subscription (additive; v1 in-memory broker)
+  "workflow.subscribe",
+  "workflow.unsubscribe",
 ];
 
 export function listGatewayMethods(): string[] {
@@ -153,4 +156,5 @@ export const GATEWAY_EVENTS = [
   "chat.turn.timeout",
   "file.uploaded",
   GATEWAY_EVENT_UPDATE_AVAILABLE,
+  "workflow.event",
 ];

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -36,6 +36,7 @@ import { usageHandlers } from "./server-methods/usage.js";
 import { voicewakeHandlers } from "./server-methods/voicewake.js";
 import { webHandlers } from "./server-methods/web.js";
 import { wizardHandlers } from "./server-methods/wizard.js";
+import { workflowHandlers } from "./server-methods/workflow.js";
 
 const CONTROL_PLANE_WRITE_METHODS = new Set(["config.apply", "config.patch", "update.run"]);
 function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["client"]) {
@@ -99,6 +100,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...agentsHandlers,
   ...browserHandlers,
   ...fileUploadHandlers,
+  ...workflowHandlers,
 };
 
 export async function handleGatewayRequest(

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -2,6 +2,7 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import type { createDefaultDeps } from "../../cli/deps.js";
 import type { HealthSummary } from "../../commands/health.js";
 import type { CronService } from "../../cron/service.js";
+import type { WorkflowEventFilter, WorkflowReplayResult } from "../../infra/workflow-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
@@ -98,6 +99,9 @@ export type GatewayRequestContext = {
     prompter: import("../../wizard/prompts.js").WizardPrompter,
   ) => Promise<void>;
   broadcastVoiceWakeChanged: (triggers: string[]) => void;
+  subscribeWorkflowEvents: (connId: string, filter: WorkflowEventFilter) => void;
+  unsubscribeWorkflowEvents: (connId: string) => void;
+  replayWorkflowEvents: (afterCursor: number, filter?: WorkflowEventFilter) => WorkflowReplayResult;
 };
 
 export type GatewayRequestOptions = {

--- a/src/gateway/server-methods/workflow.test.ts
+++ b/src/gateway/server-methods/workflow.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import {
+  emitWorkflowEvent,
+  resetWorkflowEventsForTest,
+  getWorkflowBrokerSnapshot,
+  replayWorkflowEvents,
+  subscribeWorkflowEvents,
+  unsubscribeWorkflowEvents,
+  type WorkflowEventFilter,
+} from "../../infra/workflow-events.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { workflowHandlers } from "./workflow.js";
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal fake context wired to the real broker
+// ---------------------------------------------------------------------------
+
+function makeContext() {
+  return {
+    subscribeWorkflowEvents: vi.fn((connId: string, filter: WorkflowEventFilter) => {
+      subscribeWorkflowEvents(connId, filter, () => {});
+    }),
+    unsubscribeWorkflowEvents: vi.fn((connId: string) => {
+      unsubscribeWorkflowEvents(connId);
+    }),
+    replayWorkflowEvents: vi.fn((afterCursor: number, filter?: WorkflowEventFilter) =>
+      replayWorkflowEvents(afterCursor, filter),
+    ),
+  };
+}
+
+type FakeContext = ReturnType<typeof makeContext>;
+
+function invoke(
+  method: keyof GatewayRequestHandlers,
+  params: Record<string, unknown>,
+  context: FakeContext,
+  connId = "conn-1",
+) {
+  const respond = vi.fn();
+  void workflowHandlers[method]?.({
+    req: {} as never,
+    params,
+    respond: respond as never,
+    context: context as never,
+    client: { connId, connect: { role: "operator", scopes: ["*"] } } as never,
+    isWebchatConnect: () => false,
+  });
+  return respond;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetWorkflowEventsForTest();
+});
+afterEach(() => {
+  resetWorkflowEventsForTest();
+});
+
+describe("workflow.subscribe", () => {
+  it("responds with subscribed:true", () => {
+    const ctx = makeContext();
+    const respond = invoke("workflow.subscribe", {}, ctx);
+    const [ok, result] = respond.mock.calls[0] as [boolean, Record<string, unknown>];
+    expect(ok).toBe(true);
+    expect(result.subscribed).toBe(true);
+  });
+
+  it("calls subscribeWorkflowEvents on the context", () => {
+    const ctx = makeContext();
+    invoke("workflow.subscribe", { kinds: ["run.started"] }, ctx);
+    expect(ctx.subscribeWorkflowEvents).toHaveBeenCalledWith(
+      "conn-1",
+      expect.objectContaining({ kinds: ["run.started"] }),
+    );
+  });
+
+  it("includes replay result in response", () => {
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+
+    const ctx = makeContext();
+    const respond = invoke("workflow.subscribe", { afterCursor: 0 }, ctx);
+    const [ok, result] = respond.mock.calls[0] as [
+      boolean,
+      { replayed: unknown[]; bufferHead: number; oldestCursor: number },
+    ];
+    expect(ok).toBe(true);
+    expect(result.replayed).toHaveLength(2);
+    expect(result.bufferHead).toBe(2);
+  });
+
+  it("replays only events matching kinds filter", () => {
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "subagent.spawned", ts: 2, data: {} });
+
+    const ctx = makeContext();
+    const respond = invoke("workflow.subscribe", { afterCursor: 0, kinds: ["run.started"] }, ctx);
+    const [, result] = respond.mock.calls[0] as [boolean, { replayed: unknown[] }];
+    expect(result.replayed).toHaveLength(1);
+  });
+
+  it("returns invalid request error for bad params (kinds not an array)", () => {
+    const ctx = makeContext();
+    const respond = invoke("workflow.subscribe", { kinds: "not-an-array" } as never, ctx);
+    const [ok] = respond.mock.calls[0] as [boolean];
+    expect(ok).toBe(false);
+  });
+});
+
+describe("workflow.unsubscribe", () => {
+  it("responds with unsubscribed:true", () => {
+    const ctx = makeContext();
+    const respond = invoke("workflow.unsubscribe", {}, ctx);
+    const [ok, result] = respond.mock.calls[0] as [boolean, Record<string, unknown>];
+    expect(ok).toBe(true);
+    expect(result.unsubscribed).toBe(true);
+  });
+
+  it("calls unsubscribeWorkflowEvents on the context", () => {
+    const ctx = makeContext();
+    invoke("workflow.unsubscribe", {}, ctx);
+    expect(ctx.unsubscribeWorkflowEvents).toHaveBeenCalledWith("conn-1");
+  });
+});
+
+describe("broker integration through subscribe/unsubscribe", () => {
+  it("subscription is reflected in broker state", () => {
+    subscribeWorkflowEvents("c1", {}, () => {});
+    subscribeWorkflowEvents("c2", {}, () => {});
+    expect(getWorkflowBrokerSnapshot().subscriberCount).toBe(2);
+
+    unsubscribeWorkflowEvents("c1");
+    expect(getWorkflowBrokerSnapshot().subscriberCount).toBe(1);
+  });
+
+  it("replay returns correct gap detection fields", () => {
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+
+    const result = replayWorkflowEvents(0);
+    expect(result.bufferHead).toBe(2);
+    expect(result.oldestCursor).toBe(1);
+    // afterCursor=0 < oldestCursor=1 means no gap (we got everything)
+    // afterCursor=0 returns events with cursor > 0, so both events included.
+    expect(result.events).toHaveLength(2);
+  });
+});

--- a/src/gateway/server-methods/workflow.ts
+++ b/src/gateway/server-methods/workflow.ts
@@ -1,0 +1,77 @@
+/**
+ * Gateway handlers for the workflow event subscription API.
+ *
+ * Methods:
+ *   workflow.subscribe   – register or replace a per-connection subscription
+ *   workflow.unsubscribe – remove the subscription for this connection
+ *
+ * Server event:
+ *   workflow.event – delivered to subscribed connections only
+ *
+ * Backward compatibility:
+ *   These methods are purely additive. Clients that do not call
+ *   workflow.subscribe receive no workflow.event events. Existing connections
+ *   are unaffected. See docs/workflow-events.md for the Talkyn integration
+ *   guide and fallback story.
+ */
+
+import {
+  ErrorCodes,
+  errorShape,
+  validateWorkflowSubscribeParams,
+  validateWorkflowUnsubscribeParams,
+} from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+export const workflowHandlers: GatewayRequestHandlers = {
+  "workflow.subscribe": ({ params, client, respond, context }) => {
+    if (!validateWorkflowSubscribeParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid workflow.subscribe params"),
+      );
+      return;
+    }
+    const connId = client?.connId;
+    if (!connId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "no connection id"));
+      return;
+    }
+
+    const { afterCursor, kinds, sessionKey } = params;
+    const filter = {
+      kinds,
+      sessionKey,
+    };
+
+    // Register or replace the subscriber for this connection.
+    context.subscribeWorkflowEvents(connId, filter);
+
+    // Replay buffered events if requested.
+    const replay = context.replayWorkflowEvents(afterCursor ?? 0, filter);
+
+    respond(true, {
+      subscribed: true,
+      bufferHead: replay.bufferHead,
+      oldestCursor: replay.oldestCursor,
+      replayed: replay.events,
+    });
+  },
+
+  "workflow.unsubscribe": ({ params, client, respond, context }) => {
+    if (!validateWorkflowUnsubscribeParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid workflow.unsubscribe params"),
+      );
+      return;
+    }
+    const connId = client?.connId;
+    if (connId) {
+      context.unsubscribeWorkflowEvents(connId);
+    }
+    respond(true, { unsubscribed: true });
+  },
+};

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -48,6 +48,12 @@ import {
 } from "../infra/skills-remote.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
+import { startWorkflowEventBridge } from "../infra/workflow-event-bridge.js";
+import {
+  subscribeWorkflowEvents,
+  unsubscribeWorkflowEvents,
+  replayWorkflowEvents,
+} from "../infra/workflow-events.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { resolveConfiguredDeferredChannelPluginIds } from "../plugins/channel-plugin-ids.js";
@@ -742,6 +748,10 @@ export async function startGatewayServer(
     broadcast("voicewake.changed", { triggers }, { dropIfSlow: true });
   };
   const hasMobileNodeConnected = () => hasConnectedMobileNode(nodeRegistry);
+
+  // Start workflow event bridge (maps agent lifecycle events to workflow events).
+  const stopWorkflowBridge = startWorkflowEventBridge();
+
   applyGatewayLaneConcurrency(cfgAtStart);
 
   let cronState = buildGatewayCronService({
@@ -1108,6 +1118,8 @@ export async function startGatewayServer(
     unsubscribeAllSessionEvents: (connId: string) => {
       sessionEventSubscribers.unsubscribe(connId);
       sessionMessageSubscribers.unsubscribeAll(connId);
+      // Also clean up workflow event subscriptions on disconnect.
+      unsubscribeWorkflowEvents(connId);
     },
     getSessionEventSubscriberConnIds: sessionEventSubscribers.getAll,
     registerToolEventRecipient: toolEventRecipients.add,
@@ -1121,6 +1133,21 @@ export async function startGatewayServer(
     markChannelLoggedOut,
     wizardRunner,
     broadcastVoiceWakeChanged,
+    subscribeWorkflowEvents: (connId, filter) => {
+      // Remove any previous subscription for this connId first (idempotent re-subscribe).
+      unsubscribeWorkflowEvents(connId);
+      subscribeWorkflowEvents(connId, filter, (evt) => {
+        // Deliver the workflow.event to only this connection.
+        const connSet = new Set([connId]);
+        broadcastToConnIds("workflow.event", evt, connSet, { dropIfSlow: true });
+      });
+    },
+    unsubscribeWorkflowEvents: (connId) => {
+      unsubscribeWorkflowEvents(connId);
+    },
+    replayWorkflowEvents: (afterCursor, filter) => {
+      return replayWorkflowEvents(afterCursor, filter);
+    },
   };
 
   // Store the gateway context as a fallback for plugin subagent dispatch
@@ -1343,6 +1370,7 @@ export async function startGatewayServer(
         skillsRefreshTimer = null;
       }
       skillsChangeUnsub();
+      stopWorkflowBridge();
       authRateLimiter?.dispose();
       browserAuthRateLimiter.dispose();
       stopModelPricingRefresh();

--- a/src/infra/workflow-event-bridge.test.ts
+++ b/src/infra/workflow-event-bridge.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { emitAgentEvent, resetAgentEventsForTest } from "./agent-events.js";
+import {
+  startWorkflowEventBridge,
+  resetWorkflowEventBridgeForTest,
+  emitSubagentWorkflowEvent,
+} from "./workflow-event-bridge.js";
+import { onWorkflowEvent, resetWorkflowEventsForTest } from "./workflow-events.js";
+import type { WorkflowEvent } from "./workflow-events.js";
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+  resetWorkflowEventsForTest();
+  resetWorkflowEventBridgeForTest();
+});
+afterEach(() => {
+  resetWorkflowEventBridgeForTest();
+  resetAgentEventsForTest();
+  resetWorkflowEventsForTest();
+});
+
+describe("startWorkflowEventBridge", () => {
+  it("maps lifecycle phase=start to run.started", () => {
+    startWorkflowEventBridge();
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((e) => received.push(e));
+    emitAgentEvent({ runId: "r1", stream: "lifecycle", data: { phase: "start" } });
+    unsub();
+    expect(received).toHaveLength(1);
+    expect(received[0].kind).toBe("run.started");
+    expect(received[0].runId).toBe("r1");
+  });
+
+  it("maps lifecycle phase=end to run.completed", () => {
+    startWorkflowEventBridge();
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((e) => received.push(e));
+    emitAgentEvent({ runId: "r1", stream: "lifecycle", data: { phase: "end" } });
+    unsub();
+    expect(received[0].kind).toBe("run.completed");
+  });
+
+  it("maps lifecycle phase=error to run.failed", () => {
+    startWorkflowEventBridge();
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((e) => received.push(e));
+    emitAgentEvent({ runId: "r1", stream: "lifecycle", data: { phase: "error" } });
+    unsub();
+    expect(received[0].kind).toBe("run.failed");
+  });
+
+  it("ignores non-lifecycle agent events", () => {
+    startWorkflowEventBridge();
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((e) => received.push(e));
+    emitAgentEvent({ runId: "r1", stream: "assistant", data: { text: "hello" } });
+    emitAgentEvent({ runId: "r1", stream: "tool", data: { name: "bash" } });
+    unsub();
+    expect(received).toHaveLength(0);
+  });
+
+  it("stops mapping events after stop() is called", () => {
+    const stop = startWorkflowEventBridge();
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((e) => received.push(e));
+    emitAgentEvent({ runId: "r1", stream: "lifecycle", data: { phase: "start" } });
+    stop();
+    emitAgentEvent({ runId: "r2", stream: "lifecycle", data: { phase: "end" } });
+    unsub();
+    expect(received).toHaveLength(1);
+  });
+
+  it("is idempotent: calling start twice does not double-emit", () => {
+    startWorkflowEventBridge();
+    startWorkflowEventBridge(); // second call should be a no-op
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((e) => received.push(e));
+    emitAgentEvent({ runId: "r1", stream: "lifecycle", data: { phase: "start" } });
+    unsub();
+    expect(received).toHaveLength(1);
+  });
+});
+
+describe("emitSubagentWorkflowEvent", () => {
+  it("emits subagent.spawned with correct fields", () => {
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((e) => received.push(e));
+    emitSubagentWorkflowEvent({
+      kind: "subagent.spawned",
+      runId: "run-1",
+      parentSessionKey: "agent:main",
+      childSessionKey: "agent:sub",
+      data: { label: "task" },
+    });
+    unsub();
+    expect(received).toHaveLength(1);
+    expect(received[0].kind).toBe("subagent.spawned");
+    expect(received[0].parentSessionKey).toBe("agent:main");
+    expect(received[0].childSessionKey).toBe("agent:sub");
+    expect(received[0].data.label).toBe("task");
+  });
+
+  it("emits subagent.completed and subagent.failed", () => {
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((e) => received.push(e));
+    emitSubagentWorkflowEvent({
+      kind: "subagent.completed",
+      runId: "run-2",
+      parentSessionKey: "agent:main",
+      childSessionKey: "agent:sub",
+    });
+    emitSubagentWorkflowEvent({
+      kind: "subagent.failed",
+      runId: "run-3",
+      parentSessionKey: "agent:main",
+      childSessionKey: "agent:sub2",
+      data: { outcome: "error" },
+    });
+    unsub();
+    expect(received[0].kind).toBe("subagent.completed");
+    expect(received[1].kind).toBe("subagent.failed");
+    expect(received[1].data.outcome).toBe("error");
+  });
+});

--- a/src/infra/workflow-event-bridge.ts
+++ b/src/infra/workflow-event-bridge.ts
@@ -1,0 +1,104 @@
+/**
+ * Workflow event bridge: maps existing agent-event lifecycle signals into
+ * stable WorkflowEvent envelopes via the broker.
+ *
+ * Call `startWorkflowEventBridge()` once at gateway startup. The returned
+ * stop function should be called on gateway shutdown.
+ *
+ * Mapping:
+ *   AgentEvent(stream="lifecycle", data.phase="start")  → run.started
+ *   AgentEvent(stream="lifecycle", data.phase="end")    → run.completed
+ *   AgentEvent(stream="lifecycle", data.phase="error")  → run.failed
+ *
+ * Subagent events (subagent.spawned / subagent.completed / subagent.failed)
+ * are emitted directly by the subagent registry via `emitSubagentWorkflowEvent`
+ * so this bridge does not need to duplicate that logic.
+ */
+
+import { onAgentEvent } from "./agent-events.js";
+import { emitWorkflowEvent, type WorkflowEventKind } from "./workflow-events.js";
+
+let bridgeStarted = false;
+let stopFn: (() => void) | null = null;
+
+/**
+ * Start the bridge. Idempotent: calling more than once is a no-op (the first
+ * registration wins and the returned stop function is still valid).
+ */
+export function startWorkflowEventBridge(): () => void {
+  if (bridgeStarted) {
+    return stopFn ?? (() => {});
+  }
+  bridgeStarted = true;
+
+  const unsub = onAgentEvent((agentEvt) => {
+    if (agentEvt.stream !== "lifecycle") {
+      return;
+    }
+
+    const phase = agentEvt.data?.phase;
+    let kind: WorkflowEventKind | null = null;
+    if (phase === "start") {
+      kind = "run.started";
+    } else if (phase === "end") {
+      kind = "run.completed";
+    } else if (phase === "error") {
+      kind = "run.failed";
+    }
+    if (!kind) {
+      return;
+    }
+
+    emitWorkflowEvent({
+      kind,
+      ts: agentEvt.ts,
+      sessionKey: agentEvt.sessionKey,
+      runId: agentEvt.runId,
+      data: {
+        seq: agentEvt.seq,
+        ...agentEvt.data,
+      },
+    });
+  });
+
+  stopFn = () => {
+    unsub();
+    bridgeStarted = false;
+    stopFn = null;
+  };
+  return stopFn;
+}
+
+/**
+ * Emit a subagent lifecycle workflow event. Called by the subagent registry
+ * on spawn and settle so the broker can track subagent.* events.
+ *
+ * This is a thin wrapper so registry code does not need to import the full
+ * broker module directly — only this entry point.
+ */
+export function emitSubagentWorkflowEvent(params: {
+  kind: "subagent.spawned" | "subagent.completed" | "subagent.failed";
+  runId: string;
+  parentSessionKey: string;
+  childSessionKey: string;
+  data?: Record<string, unknown>;
+}): void {
+  emitWorkflowEvent({
+    kind: params.kind,
+    ts: Date.now(),
+    runId: params.runId,
+    parentSessionKey: params.parentSessionKey,
+    childSessionKey: params.childSessionKey,
+    sessionKey: params.parentSessionKey,
+    data: params.data ?? {},
+  });
+}
+
+/** Reset for tests. */
+export function resetWorkflowEventBridgeForTest(): void {
+  if (stopFn) {
+    stopFn();
+  }
+  bridgeStarted = false;
+  stopFn = null;
+}

--- a/src/infra/workflow-events.test.ts
+++ b/src/infra/workflow-events.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  emitWorkflowEvent,
+  onWorkflowEvent,
+  subscribeWorkflowEvents,
+  unsubscribeWorkflowEvents,
+  replayWorkflowEvents,
+  waitForWorkflowEvent,
+  clearWorkflowWaitersForSession,
+  matchesWorkflowFilter,
+  resetWorkflowEventsForTest,
+  getWorkflowBrokerSnapshot,
+  type WorkflowEvent,
+} from "./workflow-events.js";
+
+beforeEach(() => {
+  resetWorkflowEventsForTest();
+});
+afterEach(() => {
+  resetWorkflowEventsForTest();
+});
+
+// ---------------------------------------------------------------------------
+// Emit + envelope
+// ---------------------------------------------------------------------------
+
+describe("emitWorkflowEvent", () => {
+  it("assigns a cursor that increments with each emit", () => {
+    const e1 = emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    const e2 = emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+    expect(e1.cursor).toBe(1);
+    expect(e2.cursor).toBe(2);
+  });
+
+  it("assigns a unique id to each event", () => {
+    const e1 = emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    const e2 = emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    expect(e1.id).not.toBe(e2.id);
+    expect(typeof e1.id).toBe("string");
+  });
+
+  it("includes all provided fields in the emitted event", () => {
+    const evt = emitWorkflowEvent({
+      kind: "subagent.spawned",
+      ts: 1234,
+      sessionKey: "agent:main",
+      runId: "run-1",
+      parentSessionKey: "agent:main",
+      childSessionKey: "agent:sub",
+      data: { label: "task-a" },
+    });
+    expect(evt.kind).toBe("subagent.spawned");
+    expect(evt.sessionKey).toBe("agent:main");
+    expect(evt.runId).toBe("run-1");
+    expect(evt.childSessionKey).toBe("agent:sub");
+    expect(evt.data.label).toBe("task-a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Replay buffer
+// ---------------------------------------------------------------------------
+
+describe("replayWorkflowEvents", () => {
+  it("returns empty results when buffer is empty", () => {
+    const result = replayWorkflowEvents(0);
+    expect(result.events).toHaveLength(0);
+    expect(result.bufferHead).toBe(0);
+    expect(result.oldestCursor).toBe(0);
+  });
+
+  it("replays all events when afterCursor=0", () => {
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+    const result = replayWorkflowEvents(0);
+    expect(result.events).toHaveLength(2);
+  });
+
+  it("replays only events after the given cursor", () => {
+    const e1 = emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+    const result = replayWorkflowEvents(e1.cursor);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].kind).toBe("run.completed");
+  });
+
+  it("reports correct bufferHead and oldestCursor", () => {
+    const e1 = emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    const e2 = emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+    const result = replayWorkflowEvents(0);
+    expect(result.bufferHead).toBe(e2.cursor);
+    expect(result.oldestCursor).toBe(e1.cursor);
+  });
+
+  it("filters by kind during replay", () => {
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+    emitWorkflowEvent({ kind: "subagent.spawned", ts: 3, data: {} });
+    const result = replayWorkflowEvents(0, { kinds: ["run.started", "run.completed"] });
+    expect(result.events).toHaveLength(2);
+    expect(result.events.every((e) => ["run.started", "run.completed"].includes(e.kind))).toBe(
+      true,
+    );
+  });
+
+  it("filters by sessionKey during replay", () => {
+    emitWorkflowEvent({ kind: "run.started", ts: 1, sessionKey: "agent:a", data: {} });
+    emitWorkflowEvent({ kind: "run.started", ts: 2, sessionKey: "agent:b", data: {} });
+    const result = replayWorkflowEvents(0, { sessionKey: "agent:a" });
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].sessionKey).toBe("agent:a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter matching
+// ---------------------------------------------------------------------------
+
+describe("matchesWorkflowFilter", () => {
+  const mkEvt = (partial: Partial<WorkflowEvent>): WorkflowEvent => ({
+    id: "id",
+    cursor: 1,
+    kind: "run.started",
+    ts: 0,
+    data: {},
+    ...partial,
+  });
+
+  it("matches any event when filter is empty", () => {
+    expect(matchesWorkflowFilter(mkEvt({ kind: "run.started" }), {})).toBe(true);
+  });
+
+  it("matches by kind", () => {
+    const evt = mkEvt({ kind: "subagent.completed" });
+    expect(matchesWorkflowFilter(evt, { kinds: ["subagent.completed"] })).toBe(true);
+    expect(matchesWorkflowFilter(evt, { kinds: ["run.started"] })).toBe(false);
+  });
+
+  it("matches sessionKey against event sessionKey, parentSessionKey, and childSessionKey", () => {
+    const evtA = mkEvt({ sessionKey: "agent:a" });
+    const evtB = mkEvt({ parentSessionKey: "agent:a" });
+    const evtC = mkEvt({ childSessionKey: "agent:a" });
+    const evtD = mkEvt({ sessionKey: "agent:b" });
+
+    expect(matchesWorkflowFilter(evtA, { sessionKey: "agent:a" })).toBe(true);
+    expect(matchesWorkflowFilter(evtB, { sessionKey: "agent:a" })).toBe(true);
+    expect(matchesWorkflowFilter(evtC, { sessionKey: "agent:a" })).toBe(true);
+    expect(matchesWorkflowFilter(evtD, { sessionKey: "agent:a" })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subscriptions
+// ---------------------------------------------------------------------------
+
+describe("subscribeWorkflowEvents / unsubscribeWorkflowEvents", () => {
+  it("delivers events to a subscriber", () => {
+    const received: WorkflowEvent[] = [];
+    subscribeWorkflowEvents("conn-1", {}, (evt) => received.push(evt));
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    expect(received).toHaveLength(1);
+    expect(received[0].kind).toBe("run.started");
+  });
+
+  it("replaces existing subscription when called again with same connId", () => {
+    const received1: WorkflowEvent[] = [];
+    const received2: WorkflowEvent[] = [];
+    subscribeWorkflowEvents("conn-1", {}, (evt) => received1.push(evt));
+    subscribeWorkflowEvents("conn-1", { kinds: ["run.completed"] }, (evt) => received2.push(evt));
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+    // First subscription replaced; second only accepts run.completed
+    expect(received1).toHaveLength(0);
+    expect(received2).toHaveLength(1);
+    expect(received2[0].kind).toBe("run.completed");
+  });
+
+  it("stops delivery after unsubscribe", () => {
+    const received: WorkflowEvent[] = [];
+    subscribeWorkflowEvents("conn-1", {}, (evt) => received.push(evt));
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    unsubscribeWorkflowEvents("conn-1");
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+    expect(received).toHaveLength(1);
+  });
+
+  it("does not deliver filtered events", () => {
+    const received: WorkflowEvent[] = [];
+    subscribeWorkflowEvents("conn-1", { kinds: ["subagent.completed"] }, (evt) =>
+      received.push(evt),
+    );
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    expect(received).toHaveLength(0);
+    emitWorkflowEvent({ kind: "subagent.completed", ts: 2, data: {} });
+    expect(received).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Raw listeners
+// ---------------------------------------------------------------------------
+
+describe("onWorkflowEvent", () => {
+  it("receives all events unfiltered", () => {
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((evt) => received.push(evt));
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "subagent.failed", ts: 2, data: {} });
+    expect(received).toHaveLength(2);
+    unsub();
+  });
+
+  it("stops receiving after returned unsub is called", () => {
+    const received: WorkflowEvent[] = [];
+    const unsub = onWorkflowEvent((evt) => received.push(evt));
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    unsub();
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+    expect(received).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// One-shot waiters
+// ---------------------------------------------------------------------------
+
+describe("waitForWorkflowEvent", () => {
+  it("resolves when a matching event is emitted", async () => {
+    const promise = waitForWorkflowEvent({ kinds: ["run.completed"] }, 5000);
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} }); // no match
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: { ok: true } }); // match
+    const evt = await promise;
+    expect(evt.kind).toBe("run.completed");
+    expect(evt.data.ok).toBe(true);
+  });
+
+  it("rejects on timeout", async () => {
+    const promise = waitForWorkflowEvent({ kinds: ["run.completed"] }, 10);
+    await expect(promise).rejects.toThrow(/timed out/);
+  });
+
+  it("does not self-wake when callerSessionKey matches event sessionKey", async () => {
+    // The waiter is registered with callerSessionKey = "agent:main".
+    // An event from "agent:main" should NOT wake it.
+    const promise = waitForWorkflowEvent({ kinds: ["subagent.spawned"] }, 200, "agent:main");
+    // Self-emitted event from same session — should not wake the waiter.
+    emitWorkflowEvent({
+      kind: "subagent.spawned",
+      ts: 1,
+      sessionKey: "agent:main",
+      parentSessionKey: "agent:main",
+      childSessionKey: "agent:sub",
+      data: {},
+    });
+    // Emit from a different session — should wake the waiter.
+    emitWorkflowEvent({
+      kind: "subagent.spawned",
+      ts: 2,
+      sessionKey: "agent:other",
+      parentSessionKey: "agent:other",
+      childSessionKey: "agent:sub-2",
+      data: {},
+    });
+    const evt = await promise;
+    expect(evt.sessionKey).toBe("agent:other");
+  });
+
+  it("clears waiter on session teardown", async () => {
+    const p = waitForWorkflowEvent({}, 5000, "agent:orphan");
+    clearWorkflowWaitersForSession("agent:orphan");
+    expect(getWorkflowBrokerSnapshot().waiterCount).toBe(0);
+    // The promise will be dangling (no reject/resolve after clear); that's OK
+    // for cleanup — just ensure it doesn't leak.
+    void p;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Broker state snapshot
+// ---------------------------------------------------------------------------
+
+describe("getWorkflowBrokerSnapshot", () => {
+  it("tracks cursor and buffer size", () => {
+    const s0 = getWorkflowBrokerSnapshot();
+    expect(s0.cursor).toBe(0);
+    expect(s0.bufferSize).toBe(0);
+
+    emitWorkflowEvent({ kind: "run.started", ts: 1, data: {} });
+    emitWorkflowEvent({ kind: "run.completed", ts: 2, data: {} });
+
+    const s2 = getWorkflowBrokerSnapshot();
+    expect(s2.cursor).toBe(2);
+    expect(s2.bufferSize).toBe(2);
+  });
+});

--- a/src/infra/workflow-events.ts
+++ b/src/infra/workflow-events.ts
@@ -1,0 +1,325 @@
+/**
+ * Workflow event broker for orchestration.
+ *
+ * Provides a stable event envelope (WorkflowEvent) and an in-memory replay
+ * buffer with cursor-based replay for v1. Listeners, per-connection subscribers,
+ * and one-shot waiters are all managed here so the gateway and agent tools have
+ * a single source of truth.
+ *
+ * Design goals:
+ * - Additive / backward-compatible: nothing here breaks existing flows.
+ * - Stable public envelope: raw agent events are not exposed directly.
+ * - Replay buffer supports `afterCursor` for reconnecting clients to detect gaps.
+ */
+
+import { randomUUID } from "node:crypto";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type WorkflowEventKind =
+  | "run.started"
+  | "run.completed"
+  | "run.failed"
+  | "subagent.spawned"
+  | "subagent.completed"
+  | "subagent.failed";
+
+export type WorkflowEvent = {
+  /** Stable identifier for this event instance. */
+  id: string;
+  /** Monotonically increasing integer across all workflow events on this gateway. */
+  cursor: number;
+  kind: WorkflowEventKind;
+  ts: number;
+  /** Session that owns or originated this run. */
+  sessionKey?: string;
+  /** Run identifier (corresponds to agent run). */
+  runId?: string;
+  /** For subagent.* events: the spawning session. */
+  parentSessionKey?: string;
+  /** For subagent.* events: the spawned session. */
+  childSessionKey?: string;
+  /** Kind-specific extra fields. */
+  data: Record<string, unknown>;
+};
+
+export type WorkflowEventFilter = {
+  /** If set, only events whose kind is in this list will be delivered. */
+  kinds?: WorkflowEventKind[];
+  /** If set, only events where sessionKey, parentSessionKey, or childSessionKey matches. */
+  sessionKey?: string;
+};
+
+export type WorkflowSubscriberCallback = (evt: WorkflowEvent) => void;
+
+// ---------------------------------------------------------------------------
+// Broker state (process-global singleton so tests can reset it)
+// ---------------------------------------------------------------------------
+
+const REPLAY_BUFFER_MAX = 500;
+
+type WorkflowWaiter = {
+  id: string;
+  filter: WorkflowEventFilter;
+  resolve: (evt: WorkflowEvent) => void;
+  /** Session key of the waiting agent (to avoid self-wake). */
+  callerSessionKey?: string;
+  timer: NodeJS.Timeout | null;
+};
+
+type WorkflowSubscriber = {
+  connId: string;
+  filter: WorkflowEventFilter;
+  callback: WorkflowSubscriberCallback;
+};
+
+type WorkflowBrokerState = {
+  cursor: number;
+  buffer: WorkflowEvent[];
+  subscribers: Map<string, WorkflowSubscriber>; // keyed by connId
+  rawListeners: Set<WorkflowSubscriberCallback>;
+  waiters: Map<string, WorkflowWaiter>; // keyed by waiter id
+};
+
+const BROKER_STATE_KEY = Symbol.for("openclaw.workflowEvents.brokerState");
+
+const state = resolveGlobalSingleton<WorkflowBrokerState>(BROKER_STATE_KEY, () => ({
+  cursor: 0,
+  buffer: [],
+  subscribers: new Map(),
+  rawListeners: new Set(),
+  waiters: new Map(),
+}));
+
+// ---------------------------------------------------------------------------
+// Emit
+// ---------------------------------------------------------------------------
+
+/** Check whether an event matches a filter. */
+export function matchesWorkflowFilter(evt: WorkflowEvent, filter: WorkflowEventFilter): boolean {
+  if (filter.kinds && filter.kinds.length > 0) {
+    if (!filter.kinds.includes(evt.kind)) {
+      return false;
+    }
+  }
+  if (filter.sessionKey) {
+    const sk = filter.sessionKey;
+    if (evt.sessionKey !== sk && evt.parentSessionKey !== sk && evt.childSessionKey !== sk) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Emit a workflow event into the broker. All subscribers and waiters are
+ * notified synchronously. The event is appended to the replay buffer.
+ */
+export function emitWorkflowEvent(partial: Omit<WorkflowEvent, "id" | "cursor">): WorkflowEvent {
+  const evt: WorkflowEvent = {
+    ...partial,
+    id: randomUUID(),
+    cursor: ++state.cursor,
+  };
+
+  // Append to replay buffer, evicting oldest if full.
+  state.buffer.push(evt);
+  if (state.buffer.length > REPLAY_BUFFER_MAX) {
+    state.buffer.shift();
+  }
+
+  // Deliver to raw listeners.
+  for (const listener of state.rawListeners) {
+    try {
+      listener(evt);
+    } catch {
+      /* ignore listener errors */
+    }
+  }
+
+  // Deliver to per-connection subscribers.
+  for (const sub of state.subscribers.values()) {
+    if (!matchesWorkflowFilter(evt, sub.filter)) {
+      continue;
+    }
+    try {
+      sub.callback(evt);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // Wake one-shot waiters.
+  for (const [waiterId, waiter] of state.waiters) {
+    if (!matchesWorkflowFilter(evt, waiter.filter)) {
+      continue;
+    }
+    // Avoid self-wake: if the event originates from the same session as the
+    // waiter's orchestrator turn, skip it. The orchestrator already knows what
+    // it just did; waking itself would create an infinite loop footgun.
+    if (
+      waiter.callerSessionKey &&
+      (evt.sessionKey === waiter.callerSessionKey ||
+        evt.parentSessionKey === waiter.callerSessionKey)
+    ) {
+      continue;
+    }
+    state.waiters.delete(waiterId);
+    if (waiter.timer) {
+      clearTimeout(waiter.timer);
+    }
+    try {
+      waiter.resolve(evt);
+    } catch {
+      /* ignore */
+    }
+    // Only wake the first matching waiter per event (one-shot semantics).
+    break;
+  }
+
+  return evt;
+}
+
+// ---------------------------------------------------------------------------
+// Subscriptions (for gateway per-connection delivery)
+// ---------------------------------------------------------------------------
+
+/** Register or replace a per-connection subscriber. */
+export function subscribeWorkflowEvents(
+  connId: string,
+  filter: WorkflowEventFilter,
+  callback: WorkflowSubscriberCallback,
+): void {
+  state.subscribers.set(connId, { connId, filter, callback });
+}
+
+/** Remove a per-connection subscriber. */
+export function unsubscribeWorkflowEvents(connId: string): void {
+  state.subscribers.delete(connId);
+}
+
+// ---------------------------------------------------------------------------
+// Raw listeners (for internal use, e.g. bridge + tests)
+// ---------------------------------------------------------------------------
+
+/** Subscribe to all workflow events (unfiltered). Returns an unsubscribe fn. */
+export function onWorkflowEvent(listener: WorkflowSubscriberCallback): () => void {
+  state.rawListeners.add(listener);
+  return () => state.rawListeners.delete(listener);
+}
+
+// ---------------------------------------------------------------------------
+// Replay
+// ---------------------------------------------------------------------------
+
+export type WorkflowReplayResult = {
+  events: WorkflowEvent[];
+  /**
+   * The cursor of the most recent event in the full buffer (not just the
+   * replayed slice). Clients can compare this with the last event they see to
+   * detect whether a gap has occurred and decide to do a full refresh.
+   */
+  bufferHead: number;
+  /**
+   * The oldest cursor in the replay buffer. If `afterCursor` is older than
+   * this, events before `oldestCursor` have already been evicted and the
+   * client should treat it as a gap.
+   */
+  oldestCursor: number;
+};
+
+/**
+ * Return buffered events after `afterCursor`, optionally filtered.
+ * Pass `afterCursor = 0` to get all buffered events.
+ */
+export function replayWorkflowEvents(
+  afterCursor: number,
+  filter?: WorkflowEventFilter,
+): WorkflowReplayResult {
+  const oldest = state.buffer.length > 0 ? (state.buffer[0]?.cursor ?? 0) : 0;
+  const head = state.buffer.length > 0 ? (state.buffer[state.buffer.length - 1]?.cursor ?? 0) : 0;
+  const events = state.buffer.filter(
+    (e) => e.cursor > afterCursor && (!filter || matchesWorkflowFilter(e, filter)),
+  );
+  return { events, bufferHead: head, oldestCursor: oldest };
+}
+
+// ---------------------------------------------------------------------------
+// One-shot waiters (for orchestrator session wait/wake)
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a one-shot waiter that resolves when a matching event is emitted.
+ * Returns a promise that resolves to the matching event, or rejects on timeout.
+ *
+ * @param callerSessionKey  If provided, prevents self-wake when the caller's
+ *   own run emits an event matching the filter.
+ */
+export function waitForWorkflowEvent(
+  filter: WorkflowEventFilter,
+  timeoutMs: number,
+  callerSessionKey?: string,
+): Promise<WorkflowEvent> {
+  return new Promise((resolve, reject) => {
+    const id = randomUUID();
+    const timer =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            state.waiters.delete(id);
+            reject(new Error(`workflow_wait timed out after ${timeoutMs}ms`));
+          }, timeoutMs)
+        : null;
+
+    state.waiters.set(id, {
+      id,
+      filter,
+      resolve,
+      callerSessionKey,
+      timer,
+    });
+  });
+}
+
+/**
+ * Cancel all pending waiters for a given session (call on session teardown).
+ */
+export function clearWorkflowWaitersForSession(sessionKey: string): void {
+  for (const [id, waiter] of state.waiters) {
+    if (waiter.callerSessionKey === sessionKey) {
+      state.waiters.delete(id);
+      if (waiter.timer) {
+        clearTimeout(waiter.timer);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+export function resetWorkflowEventsForTest(): void {
+  state.cursor = 0;
+  state.buffer.length = 0;
+  state.subscribers.clear();
+  state.rawListeners.clear();
+  for (const waiter of state.waiters.values()) {
+    if (waiter.timer) {
+      clearTimeout(waiter.timer);
+    }
+  }
+  state.waiters.clear();
+}
+
+/** Snapshot of current broker state for assertions. */
+export function getWorkflowBrokerSnapshot() {
+  return {
+    cursor: state.cursor,
+    bufferSize: state.buffer.length,
+    subscriberCount: state.subscribers.size,
+    waiterCount: state.waiters.size,
+  };
+}


### PR DESCRIPTION
## Summary
- add a workflow event broker with replay, filtering, and cursor-based reconnect support
- expose additive gateway APIs for `workflow.subscribe`, `workflow.unsubscribe`, and `workflow.event`
- bridge agent lifecycle + subagent lifecycle into stable workflow events and add a `workflow_wait` tool for yield/wake orchestration
- document Talkyn/client integration and regenerate Swift protocol models
- add focused gateway + infra tests for broker, bridge, and subscription behavior

## Verification
- `pnpm check`
- `pnpm build:strict-smoke`
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server-methods/workflow.test.ts`
- `pnpm vitest run --config vitest.unit.config.ts src/infra/workflow-events.test.ts src/infra/workflow-event-bridge.test.ts`

Closes #12
