### PR TITLE
fix(gateway): stream ACP transcript appends live

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -325,27 +325,40 @@ async function persistAcpTurnTranscript(params: {
   });
 
   if (promptText) {
-    sessionManager.appendMessage({
-      role: "user",
+    const message = {
+      role: "user" as const,
       content: promptText,
       timestamp: Date.now(),
+    };
+    const messageId = sessionManager.appendMessage(message);
+    emitSessionTranscriptUpdate({
+      sessionFile,
+      sessionKey: params.sessionKey,
+      message,
+      ...(typeof messageId === "string" ? { messageId } : {}),
     });
   }
 
   if (replyText) {
-    sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: replyText }],
+    const message = {
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: replyText }],
       api: "openai-responses",
       provider: "openclaw",
       model: "acp-runtime",
       usage: ACP_TRANSCRIPT_USAGE,
-      stopReason: "stop",
+      stopReason: "stop" as const,
       timestamp: Date.now(),
+    };
+    const messageId = sessionManager.appendMessage(message);
+    emitSessionTranscriptUpdate({
+      sessionFile,
+      sessionKey: params.sessionKey,
+      message,
+      ...(typeof messageId === "string" ? { messageId } : {}),
     });
   }
 
-  emitSessionTranscriptUpdate(sessionFile);
   return sessionEntry;
 }
 
@@ -1331,3 +1344,7 @@ export async function agentCommandFromIngress(
     deps,
   );
 }
+
+export const __testing = {
+  persistAcpTurnTranscript,
+};

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { loadSessionStore } from "../config/sessions.js";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { testState } from "./test-helpers.mocks.js";
@@ -169,6 +170,141 @@ describe("session.message websocket events", () => {
         ).toMatchObject({
           id: appended.ok ? appended.messageId : undefined,
           seq: 1,
+        });
+      } finally {
+        ws.close();
+      }
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("streams ACP transcript persistence appends live over websocket", async () => {
+    const storePath = await createSessionStoreFile();
+    const transcriptPath = path.join(path.dirname(storePath), "sess-main.jsonl");
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          sessionFile: transcriptPath,
+          updatedAt: Date.now(),
+        },
+      },
+      storePath,
+    });
+
+    const sessionStore = loadSessionStore(storePath, { skipCache: true });
+    const sessionEntry = sessionStore["agent:main:main"];
+    if (!sessionEntry) {
+      throw new Error("expected session store entry for agent:main:main");
+    }
+
+    const harness = await createGatewaySuiteHarness();
+    try {
+      const ws = await harness.openWs();
+      try {
+        await connectOk(ws, { scopes: ["operator.read"] });
+        await rpcReq(ws, "sessions.subscribe");
+
+        const { __testing } = await import("../agents/agent-command.js");
+        const userEventPromise = onceMessage(
+          ws,
+          (message) =>
+            message.type === "event" &&
+            message.event === "session.message" &&
+            (message.payload as { sessionKey?: string; message?: { role?: string } } | undefined)
+              ?.sessionKey === "agent:main:main" &&
+            (
+              message.payload as {
+                sessionKey?: string;
+                message?: { role?: string };
+              }
+            ).message?.role === "user",
+        );
+        const assistantEventPromise = onceMessage(
+          ws,
+          (message) =>
+            message.type === "event" &&
+            message.event === "session.message" &&
+            (message.payload as { sessionKey?: string; message?: { role?: string } } | undefined)
+              ?.sessionKey === "agent:main:main" &&
+            (
+              message.payload as {
+                sessionKey?: string;
+                message?: { role?: string };
+              }
+            ).message?.role === "assistant",
+        );
+
+        await __testing.persistAcpTurnTranscript({
+          body: "heartbeat please",
+          finalText: "still alive",
+          sessionId: "sess-main",
+          sessionKey: "agent:main:main",
+          sessionEntry,
+          sessionStore,
+          storePath,
+          sessionAgentId: "main",
+          sessionCwd: path.dirname(storePath),
+        });
+
+        const [userEvent, assistantEvent] = await Promise.all([
+          userEventPromise,
+          assistantEventPromise,
+        ]);
+
+        expect(userEvent.payload).toMatchObject({
+          sessionKey: "agent:main:main",
+          messageId: expect.any(String),
+          messageSeq: expect.any(Number),
+          message: {
+            role: "user",
+            content: "heartbeat please",
+            __openclaw: {
+              id: expect.any(String),
+              seq: expect.any(Number),
+            },
+          },
+        });
+        expect(assistantEvent.payload).toMatchObject({
+          sessionKey: "agent:main:main",
+          messageId: expect.any(String),
+          messageSeq: expect.any(Number),
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "still alive" }],
+            __openclaw: {
+              id: expect.any(String),
+              seq: expect.any(Number),
+            },
+          },
+        });
+        expect((userEvent.payload as { messageId?: string }).messageId).toBe(
+          (
+            userEvent.payload as {
+              message?: { __openclaw?: { id?: string; seq?: number } };
+            }
+          ).message?.__openclaw?.id,
+        );
+        expect((assistantEvent.payload as { messageId?: string }).messageId).toBe(
+          (
+            assistantEvent.payload as {
+              message?: { __openclaw?: { id?: string; seq?: number } };
+            }
+          ).message?.__openclaw?.id,
+        );
+
+        await expectNoMessageWithin({
+          watch: () =>
+            onceMessage(
+              ws,
+              (message) =>
+                message.type === "event" &&
+                message.event === "session.message" &&
+                (message.payload as { sessionKey?: string } | undefined)?.sessionKey ===
+                  "agent:main:main",
+              300,
+            ),
         });
       } finally {
         ws.close();


### PR DESCRIPTION
## Summary
- stream ACP-persisted transcript appends live over the session WebSocket
- emit structured transcript updates with message + messageId for both persisted ACP user and assistant turns
- add a gateway regression test covering live websocket delivery for ACP transcript persistence

## Root cause
The ACP transcript persistence path appended messages to session history, but only emitted a bare transcript update without the appended message payload. The gateway only pushes live `session.message` events when the transcript update includes the appended message, so those turns appeared after refresh/history reload but were not streamed live when they happened.

## Verification
- pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/session-message-events.test.ts
- pnpm exec vitest run --config vitest.unit.config.ts src/sessions/transcript-events.test.ts

Fixes #16
