### PR TITLE
feat: add sessions archive command and tool

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -87,6 +87,8 @@ describe("sessions tools", () => {
     expect(schemaProp("sessions_list", "limit").type).toBe("number");
     expect(schemaProp("sessions_list", "activeMinutes").type).toBe("number");
     expect(schemaProp("sessions_list", "messageLimit").type).toBe("number");
+    expect(schemaProp("sessions_archive", "allAgents").type).toBe("boolean");
+    expect(schemaProp("sessions_archive", "olderThan").type).toBe("string");
     expect(schemaProp("sessions_send", "timeoutSeconds").type).toBe("number");
     expect(schemaProp("sessions_spawn", "thinking").type).toBe("string");
     expect(schemaProp("sessions_spawn", "runTimeoutSeconds").type).toBe("number");
@@ -828,7 +830,7 @@ describe("sessions tools", () => {
     );
     expect(replySteps).toHaveLength(2);
     expect(sendParams).toMatchObject({
-      to: "channel:target",
+      to: "group:target",
       channel: "discord",
       message: "announce now",
     });

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -18,6 +18,7 @@ import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
+import { createSessionsArchiveTool } from "./tools/sessions-archive-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
@@ -186,6 +187,7 @@ export function createOpenClawTools(
       sandboxed: options?.sandboxed,
       config: options?.config,
     }),
+    createSessionsArchiveTool(),
     createSessionsHistoryTool({
       agentSessionKey: options?.agentSessionKey,
       sandboxed: options?.sandboxed,

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -10,6 +10,7 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "compaction",
     data: { phase: "start" },
   });
@@ -63,6 +64,7 @@ export function handleAutoCompactionEnd(
   }
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "compaction",
     data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
   });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -18,6 +18,7 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "lifecycle",
     data: {
       phase: "start",
@@ -66,6 +67,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     });
     emitAgentEvent({
       runId: ctx.params.runId,
+      sessionKey: ctx.params.sessionKey,
       stream: "lifecycle",
       data: {
         phase: "error",
@@ -84,6 +86,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     ctx.log.debug(`embedded run agent end: runId=${ctx.params.runId} isError=${isError}`);
     emitAgentEvent({
       runId: ctx.params.runId,
+      sessionKey: ctx.params.sessionKey,
       stream: "lifecycle",
       data: {
         phase: "end",

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -246,6 +246,7 @@ export function handleMessageUpdate(
       });
       emitAgentEvent({
         runId: ctx.params.runId,
+        sessionKey: ctx.params.sessionKey,
         stream: "assistant",
         data,
       });
@@ -329,6 +330,7 @@ export function handleMessageEnd(
     });
     emitAgentEvent({
       runId: ctx.params.runId,
+      sessionKey: ctx.params.sessionKey,
       stream: "assistant",
       data,
     });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -340,6 +340,7 @@ export async function handleToolExecutionStart(
   const shouldEmitToolEvents = ctx.shouldEmitToolResult();
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "tool",
     data: {
       phase: "start",
@@ -401,6 +402,7 @@ export function handleToolExecutionUpdate(
   const sanitized = sanitizeToolResult(partial);
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "tool",
     data: {
       phase: "update",
@@ -520,6 +522,7 @@ export async function handleToolExecutionEnd(
 
   emitAgentEvent({
     runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
     stream: "tool",
     data: {
       phase: "result",

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { onAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
 import {
   THINKING_TAG_CASES,
   createStubSessionHarness,
@@ -12,6 +13,10 @@ import {
 import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
 
 describe("subscribeEmbeddedPiSession", () => {
+  afterEach(() => {
+    resetAgentEventsForTest();
+  });
+
   function createAgentEventHarness(options?: { runId?: string; sessionKey?: string }) {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();
@@ -106,7 +111,7 @@ describe("subscribeEmbeddedPiSession", () => {
 
   it.each(THINKING_TAG_CASES)(
     "streams <%s> reasoning via onReasoningStream without leaking into final text",
-    ({ open, close }) => {
+    async ({ open, close }) => {
       const onReasoningStream = vi.fn();
       const onBlockReply = vi.fn();
 
@@ -132,6 +137,7 @@ describe("subscribeEmbeddedPiSession", () => {
       } as AssistantMessage;
 
       emit({ type: "message_end", message: assistantMessage });
+      await Promise.resolve();
 
       expect(onBlockReply).toHaveBeenCalledTimes(1);
       expect(onBlockReply.mock.calls[0][0].text).toBe("Final answer");
@@ -149,7 +155,7 @@ describe("subscribeEmbeddedPiSession", () => {
   );
   it.each(THINKING_TAG_CASES)(
     "suppresses <%s> blocks across chunk boundaries",
-    ({ open, close }) => {
+    async ({ open, close }) => {
       const onBlockReply = vi.fn();
 
       const { emit } = createSubscribedHarness({
@@ -174,6 +180,7 @@ describe("subscribeEmbeddedPiSession", () => {
         message: { role: "assistant" },
         assistantMessageEvent: { type: "text_end" },
       });
+      await Promise.resolve();
 
       const payloadTexts = onBlockReply.mock.calls
         .map((call) => call[0]?.text)
@@ -227,6 +234,107 @@ describe("subscribeEmbeddedPiSession", () => {
       .filter((value): value is string => typeof value === "string");
     expect(streamTexts.at(-1)).toBe("Reasoning:\n_Checking files done_");
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits thinking agent events in stream mode even without onReasoningStream callback", () => {
+    resetAgentEventsForTest();
+    const seen: Array<{ stream?: string; sessionKey?: string; data?: Record<string, unknown> }> =
+      [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-thinking-no-callback") {
+        seen.push(evt);
+      }
+    });
+
+    try {
+      const { emit } = createSubscribedHarness({
+        runId: "run-thinking-no-callback",
+        reasoningMode: "stream",
+        sessionKey: "session-thinking",
+      });
+
+      emit({
+        type: "message_update",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "Checking files" }],
+        },
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          delta: "Checking files",
+        },
+      });
+
+      expect(seen).toContainEqual(
+        expect.objectContaining({
+          stream: "thinking",
+          sessionKey: "session-thinking",
+          data: expect.objectContaining({
+            text: "Reasoning:\n_Checking files_",
+            delta: "Reasoning:\n_Checking files_",
+          }),
+        }),
+      );
+    } finally {
+      stop();
+    }
+  });
+
+  it("emits explicit sessionKey on assistant/tool/compaction/lifecycle streams", async () => {
+    resetAgentEventsForTest();
+    const seen: Array<{ stream?: string; sessionKey?: string; data?: Record<string, unknown> }> =
+      [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-explicit-session-key") {
+        seen.push(evt);
+      }
+    });
+
+    try {
+      const { emit } = createSubscribedHarness({
+        runId: "run-explicit-session-key",
+        sessionKey: "session-explicit",
+      });
+
+      emit({ type: "agent_start" });
+      emit({ type: "message_start", message: { role: "assistant" } });
+      emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: { type: "text_delta", delta: "Hello" },
+      });
+      emit({
+        type: "tool_execution_start",
+        toolName: "read",
+        toolCallId: "tool-1",
+        args: { path: "/tmp/demo.txt" },
+      });
+      emit({ type: "auto_compaction_start" });
+      emit({ type: "auto_compaction_end", result: { ok: true } });
+      emit({ type: "agent_end" });
+      await Promise.resolve();
+
+      expect(
+        seen
+          .filter(
+            (evt) =>
+              evt.stream === "assistant" ||
+              evt.stream === "tool" ||
+              evt.stream === "compaction" ||
+              evt.stream === "lifecycle",
+          )
+          .map((evt) => ({ stream: evt.stream, sessionKey: evt.sessionKey })),
+      ).toEqual([
+        { stream: "lifecycle", sessionKey: "session-explicit" },
+        { stream: "assistant", sessionKey: "session-explicit" },
+        { stream: "tool", sessionKey: "session-explicit" },
+        { stream: "compaction", sessionKey: "session-explicit" },
+        { stream: "compaction", sessionKey: "session-explicit" },
+        { stream: "lifecycle", sessionKey: "session-explicit" },
+      ]);
+    } finally {
+      stop();
+    }
   });
 
   it("emits reasoning end once when native and tagged reasoning end overlap", () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -45,7 +45,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     reasoningMode,
     includeReasoning: reasoningMode === "on",
     shouldEmitPartialReplies: !(reasoningMode === "on" && !params.onBlockReply),
-    streamReasoning: reasoningMode === "stream" && typeof params.onReasoningStream === "function",
+    // Control UI consumes live thinking via agent events; do not require a
+    // separate onReasoningStream callback just to open the stream.
+    streamReasoning: reasoningMode === "stream",
     deltaBuffer: "",
     blockBuffer: "",
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
@@ -554,7 +556,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   const emitReasoningStream = (text: string) => {
-    if (!state.streamReasoning || !params.onReasoningStream) {
+    if (!state.streamReasoning) {
       return;
     }
     const formatted = formatReasoningMessage(text);
@@ -573,6 +575,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Broadcast thinking event to WebSocket clients in real-time
     emitAgentEvent({
       runId: params.runId,
+      sessionKey: params.sessionKey,
       stream: "thinking",
       data: {
         text: formatted,
@@ -580,7 +583,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       },
     });
 
-    void params.onReasoningStream({
+    void params.onReasoningStream?.({
       text: formatted,
     });
   };

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -125,12 +125,13 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("sessions_history", policy)).toBe(true);
   });
 
-  it("depth-1 orchestrator still denies gateway, cron, memory", () => {
+  it("depth-1 orchestrator still denies gateway, cron, memory, and sessions_archive", () => {
     const policy = resolveSubagentToolPolicy(baseCfg, 1);
     expect(isToolAllowedByPolicyName("gateway", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("cron", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("sessions_archive", policy)).toBe(false);
   });
 
   it("depth-2 leaf denies sessions_spawn", () => {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -35,6 +35,8 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   "memory_get",
   // Direct session sends - subagents communicate through announce chain
   "sessions_send",
+  // Session archiving is coordinator-owned and destructive.
+  "sessions_archive",
 ];
 
 /**

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -19,6 +19,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "apply_patch",
   "image",
   "sessions_list",
+  "sessions_archive",
   "sessions_history",
   "sessions_send",
   "sessions_spawn",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -246,6 +246,8 @@ export function buildAgentSystemPrompt(params: {
       ? 'List OpenClaw agent ids allowed for sessions_spawn when runtime="subagent" (not ACP harness ids)'
       : "List OpenClaw agent ids allowed for sessions_spawn",
     sessions_list: "List other sessions (incl. sub-agents) with filters/last",
+    sessions_archive:
+      "Archive one session or batch-archive completed sessions by filters (never active, main, or cron sessions)",
     sessions_history: "Fetch history for another session/sub-agent",
     sessions_send: "Send a message to another session/sub-agent",
     sessions_spawn: acpSpawnRuntimeEnabled
@@ -278,6 +280,7 @@ export function buildAgentSystemPrompt(params: {
     "gateway",
     "agents_list",
     "sessions_list",
+    "sessions_archive",
     "sessions_history",
     "sessions_send",
     "subagents",

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -122,6 +122,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "sessions_archive",
+    label: "sessions_archive",
+    description: "Archive sessions",
+    sectionId: "sessions",
+    profiles: ["coding", "messaging"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "sessions_history",
     label: "sessions_history",
     description: "Session history",

--- a/src/agents/tool-display-overrides.json
+++ b/src/agents/tool-display-overrides.json
@@ -26,6 +26,11 @@
       "title": "Sessions",
       "detailKeys": ["kinds", "limit", "activeMinutes", "messageLimit"]
     },
+    "sessions_archive": {
+      "emoji": "🗄️",
+      "title": "Session Archive",
+      "detailKeys": ["sessionKey", "agent", "agentId", "allAgents", "status", "olderThan", "dryRun"]
+    },
     "sessions_send": {
       "emoji": "📨",
       "title": "Session Send",

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -66,6 +66,7 @@ describe("tool mutation helpers", () => {
   });
 
   it("keeps legacy name-only mutating heuristics for payload fallback", () => {
+    expect(isLikelyMutatingToolName("sessions_archive")).toBe(true);
     expect(isLikelyMutatingToolName("sessions_send")).toBe(true);
     expect(isLikelyMutatingToolName("browser_actions")).toBe(true);
     expect(isLikelyMutatingToolName("message_slack")).toBe(true);

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -6,6 +6,7 @@ const MUTATING_TOOL_NAMES = new Set([
   "bash",
   "process",
   "message",
+  "sessions_archive",
   "sessions_send",
   "cron",
   "gateway",
@@ -106,6 +107,7 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "apply_patch":
     case "exec":
     case "bash":
+    case "sessions_archive":
     case "sessions_send":
       return true;
     case "process":

--- a/src/agents/tools/sessions-archive-tool.test.ts
+++ b/src/agents/tools/sessions-archive-tool.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runSessionsArchiveMock = vi.fn();
+
+vi.mock("../../commands/sessions-archive-core.js", () => ({
+  runSessionsArchive: (...args: unknown[]) => runSessionsArchiveMock(...args),
+}));
+
+import { createSessionsArchiveTool } from "./sessions-archive-tool.js";
+
+describe("sessions_archive tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards archive requests to the shared archive command in json mode", async () => {
+    runSessionsArchiveMock.mockResolvedValue({
+      allAgents: true,
+      requestedKey: "agent:main:subagent:abc",
+      status: "done",
+      olderThan: "7d",
+      stores: [
+        {
+          summary: { archived: 3, skipped: 1, agentId: "main" },
+          actionRows: [],
+          eligibleKeys: [],
+        },
+      ],
+    });
+
+    const tool = createSessionsArchiveTool();
+    const result = await tool.execute?.("call-1", {
+      sessionKey: "agent:main:subagent:abc",
+      agentId: "main",
+      allAgents: true,
+      status: "done",
+      olderThan: "7d",
+      dryRun: true,
+    });
+
+    expect(runSessionsArchiveMock).toHaveBeenCalledTimes(1);
+    expect(runSessionsArchiveMock).toHaveBeenCalledWith({
+      sessionKey: "agent:main:subagent:abc",
+      agent: "main",
+      allAgents: true,
+      status: "done",
+      olderThan: "7d",
+      dryRun: true,
+    });
+    expect(result?.details).toEqual({ archived: 3, skipped: 1, agentId: "main" });
+  });
+
+  it("returns structured errors when the shared command reports a failure", async () => {
+    runSessionsArchiveMock.mockRejectedValue(
+      new Error("Cannot archive agent:main:main: protected main session."),
+    );
+
+    const tool = createSessionsArchiveTool();
+    const result = await tool.execute?.("call-2", {
+      sessionKey: "agent:main:main",
+    });
+
+    expect(result?.details).toEqual({
+      ok: false,
+      error: "Cannot archive agent:main:main: protected main session.",
+    });
+  });
+
+  it("rejects conflicting agent and agentId inputs before invoking the command", async () => {
+    const tool = createSessionsArchiveTool();
+    const result = await tool.execute?.("call-3", {
+      agent: "main",
+      agentId: "lead",
+      status: "done",
+    });
+
+    expect(runSessionsArchiveMock).not.toHaveBeenCalled();
+    expect(result?.details).toEqual({
+      ok: false,
+      error: "Provide either agent or agentId (not conflicting values for both).",
+    });
+  });
+});

--- a/src/agents/tools/sessions-archive-tool.ts
+++ b/src/agents/tools/sessions-archive-tool.ts
@@ -1,0 +1,77 @@
+import { Type } from "@sinclair/typebox";
+import { runSessionsArchive } from "../../commands/sessions-archive-core.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+
+const SessionsArchiveToolSchema = Type.Object({
+  sessionKey: Type.Optional(Type.String()),
+  agent: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
+  agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
+  allAgents: Type.Optional(Type.Boolean()),
+  status: Type.Optional(
+    Type.Union([Type.Literal("done"), Type.Literal("killed"), Type.Literal("timeout")]),
+  ),
+  olderThan: Type.Optional(Type.String({ minLength: 1 })),
+  dryRun: Type.Optional(Type.Boolean()),
+});
+
+export function createSessionsArchiveTool(): AnyAgentTool {
+  return {
+    label: "Session Archive",
+    name: "sessions_archive",
+    description:
+      "Archive one session or batch-archive completed sessions by agent/status/age. Never archives active, main, or cron sessions.",
+    parameters: SessionsArchiveToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const sessionKey = readStringParam(params, "sessionKey");
+      const agent = readStringParam(params, "agent");
+      const agentId = readStringParam(params, "agentId");
+      if (agent && agentId && agent !== agentId) {
+        return jsonResult({
+          ok: false,
+          error: "Provide either agent or agentId (not conflicting values for both).",
+        });
+      }
+
+      const statusRaw = readStringParam(params, "status")?.toLowerCase();
+      const status =
+        statusRaw && ["done", "killed", "timeout"].includes(statusRaw)
+          ? (statusRaw as "done" | "killed" | "timeout")
+          : undefined;
+      if (statusRaw && !status) {
+        return jsonResult({
+          ok: false,
+          error: "status must be one of: done, killed, timeout",
+        });
+      }
+
+      try {
+        const result = await runSessionsArchive({
+          sessionKey,
+          agent: agent ?? agentId,
+          allAgents: params.allAgents === true,
+          status,
+          olderThan: readStringParam(params, "olderThan"),
+          dryRun: params.dryRun === true,
+        });
+        if (result.stores.length === 1) {
+          return jsonResult(result.stores[0]?.summary ?? {});
+        }
+        return jsonResult({
+          allAgents: result.allAgents,
+          dryRun: params.dryRun === true,
+          requestedKey: result.requestedKey,
+          status: result.status,
+          olderThan: result.olderThan,
+          stores: result.stores.map((store) => store.summary),
+        });
+      } catch (error) {
+        return jsonResult({
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  };
+}

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const statusCommand = vi.fn();
 const healthCommand = vi.fn();
 const sessionsCommand = vi.fn();
+const sessionsArchiveCommand = vi.fn();
 const sessionsCleanupCommand = vi.fn();
 const setVerbose = vi.fn();
 
@@ -23,6 +24,10 @@ vi.mock("../../commands/health.js", () => ({
 
 vi.mock("../../commands/sessions.js", () => ({
   sessionsCommand,
+}));
+
+vi.mock("../../commands/sessions-archive.js", () => ({
+  sessionsArchiveCommand,
 }));
 
 vi.mock("../../commands/sessions-cleanup.js", () => ({
@@ -55,6 +60,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     statusCommand.mockResolvedValue(undefined);
     healthCommand.mockResolvedValue(undefined);
     sessionsCommand.mockResolvedValue(undefined);
+    sessionsArchiveCommand.mockResolvedValue(undefined);
     sessionsCleanupCommand.mockResolvedValue(undefined);
   });
 
@@ -158,6 +164,52 @@ describe("registerStatusHealthSessionsCommands", () => {
     expect(sessionsCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         allAgents: true,
+      }),
+      runtime,
+    );
+  });
+
+  it("runs sessions archive subcommand with forwarded options", async () => {
+    await runCli([
+      "sessions",
+      "archive",
+      "agent:lead:subagent:abc",
+      "--store",
+      "/tmp/sessions.json",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(sessionsArchiveCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:lead:subagent:abc",
+        store: "/tmp/sessions.json",
+        agent: undefined,
+        allAgents: false,
+        status: undefined,
+        olderThan: undefined,
+        dryRun: true,
+        json: true,
+      }),
+      runtime,
+    );
+  });
+
+  it("rejects invalid archive status without calling archive command", async () => {
+    await runCli(["sessions", "archive", "--status", "failed"]);
+
+    expect(runtime.error).toHaveBeenCalledWith("--status must be one of: done, killed, timeout");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(sessionsArchiveCommand).not.toHaveBeenCalled();
+  });
+
+  it("forwards parent-level all-agents to archive subcommand", async () => {
+    await runCli(["sessions", "--all-agents", "archive", "--status", "done"]);
+
+    expect(sessionsArchiveCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allAgents: true,
+        status: "done",
       }),
       runtime,
     );

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { healthCommand } from "../../commands/health.js";
+import { sessionsArchiveCommand } from "../../commands/sessions-archive.js";
 import { sessionsCleanupCommand } from "../../commands/sessions-cleanup.js";
 import { sessionsCommand } from "../../commands/sessions.js";
 import { statusCommand } from "../../commands/status.js";
@@ -154,6 +155,73 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       );
     });
   sessionsCmd.enablePositionalOptions();
+
+  sessionsCmd
+    .command("archive [sessionKey]")
+    .description("Archive targeted sessions from the session store")
+    .option("--store <path>", "Path to session store (default: resolved from config)")
+    .option(
+      "--agent <id>",
+      "Agent id to archive from (default: configured/default derived from key)",
+    )
+    .option("--all-agents", "Archive across all configured agents", false)
+    .option("--status <status>", "Archive sessions with status done, killed, or timeout")
+    .option("--older-than <duration>", "Only archive sessions older than a duration (e.g. 24h, 7d)")
+    .option("--dry-run", "Preview archive actions without writing", false)
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw sessions archive agent:lead:subagent:abc", "Archive one specific session."],
+          [
+            "openclaw sessions archive --agent lead --status done",
+            "Archive completed lead sessions.",
+          ],
+          [
+            "openclaw sessions archive --all-agents --status done --older-than 7d --dry-run",
+            "Preview completed sessions older than 7 days across all agents.",
+          ],
+        ])}`,
+    )
+    .action(async (sessionKey, opts, command) => {
+      const parentOpts = command.parent?.opts() as
+        | {
+            store?: string;
+            agent?: string;
+            allAgents?: boolean;
+            json?: boolean;
+          }
+        | undefined;
+      const rawStatus = String(opts.status ?? "")
+        .trim()
+        .toLowerCase();
+      const status = rawStatus
+        ? ["done", "killed", "timeout"].includes(rawStatus)
+          ? rawStatus
+          : undefined
+        : undefined;
+      if (rawStatus && !status) {
+        defaultRuntime.error("--status must be one of: done, killed, timeout");
+        defaultRuntime.exit(1);
+        return;
+      }
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sessionsArchiveCommand(
+          {
+            sessionKey: typeof sessionKey === "string" ? sessionKey : undefined,
+            store: (opts.store as string | undefined) ?? parentOpts?.store,
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
+            allAgents: Boolean(opts.allAgents || parentOpts?.allAgents),
+            status: status as "done" | "killed" | "timeout" | undefined,
+            olderThan: opts.olderThan as string | undefined,
+            dryRun: Boolean(opts.dryRun),
+            json: Boolean(opts.json || parentOpts?.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
 
   sessionsCmd
     .command("cleanup")

--- a/src/commands/sessions-archive-core.ts
+++ b/src/commands/sessions-archive-core.ts
@@ -1,0 +1,376 @@
+import { parseDurationMs } from "../cli/parse-duration.js";
+import { loadConfig, type OpenClawConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveSessionStoreTargets,
+  type SessionEntry,
+  type SessionStoreTarget,
+  updateSessionStore,
+} from "../config/sessions.js";
+import { archiveSessionTranscripts } from "../gateway/session-utils.js";
+import {
+  isCronSessionKey,
+  normalizeMainKey,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
+import { toSessionDisplayRows } from "./sessions-table.js";
+
+export type SessionsArchiveStatus = "done" | "killed" | "timeout";
+
+export type SessionsArchiveOptions = {
+  sessionKey?: string;
+  store?: string;
+  agent?: string;
+  allAgents?: boolean;
+  status?: SessionsArchiveStatus;
+  olderThan?: string;
+  dryRun?: boolean;
+};
+
+export type SessionArchiveAction = "archive" | "skip";
+export type SessionArchiveSkipReason = "active" | "main" | "cron";
+
+export type SessionArchiveActionRow = ReturnType<typeof toSessionDisplayRows>[number] & {
+  action: SessionArchiveAction;
+  status: string | null;
+  reason: SessionArchiveSkipReason | null;
+};
+
+export type SessionArchiveSummary = {
+  agentId: string;
+  storePath: string;
+  dryRun: boolean;
+  requestedKey: string | null;
+  status: SessionsArchiveStatus | null;
+  olderThan: string | null;
+  olderThanMs: number | null;
+  totalEntries: number;
+  matched: number;
+  eligible: number;
+  skipped: number;
+  archived: number;
+  transcriptFilesArchived: number;
+  wouldMutate: boolean;
+};
+
+export type SessionsArchiveStoreResult = {
+  summary: SessionArchiveSummary;
+  actionRows: SessionArchiveActionRow[];
+  eligibleKeys: string[];
+};
+
+export type SessionsArchiveRunResult = {
+  allAgents: boolean;
+  requestedKey: string | null;
+  status: SessionsArchiveStatus | null;
+  olderThan: string | null;
+  stores: SessionsArchiveStoreResult[];
+};
+
+export class SessionsArchiveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionsArchiveError";
+  }
+}
+
+function normalizeStatus(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function isActiveSession(entry: SessionEntry | undefined): boolean {
+  const status = normalizeStatus(entry?.status);
+  return status === "running" || status === "active" || status?.startsWith("active ") === true;
+}
+
+function isProtectedMainSession(params: { key: string; cfg: OpenClawConfig }): boolean {
+  const trimmed = params.key.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed === "global") {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(trimmed);
+  if (!parsed) {
+    return trimmed === normalizeMainKey(params.cfg.session?.mainKey);
+  }
+  return parsed.rest === normalizeMainKey(params.cfg.session?.mainKey);
+}
+
+function resolveSkipReason(params: {
+  key: string;
+  entry: SessionEntry | undefined;
+  cfg: OpenClawConfig;
+}): SessionArchiveSkipReason | null {
+  if (isProtectedMainSession({ key: params.key, cfg: params.cfg })) {
+    return "main";
+  }
+  if (isCronSessionKey(params.key) || params.key.includes(":cron:")) {
+    return "cron";
+  }
+  if (isActiveSession(params.entry)) {
+    return "active";
+  }
+  return null;
+}
+
+export function formatArchiveReason(reason: SessionArchiveSkipReason | null): string {
+  if (reason === "main") {
+    return "protected main session";
+  }
+  if (reason === "cron") {
+    return "protected cron session";
+  }
+  if (reason === "active") {
+    return "session still active";
+  }
+  return "";
+}
+
+function resolveStoreArchiveCandidates(params: {
+  cfg: OpenClawConfig;
+  store: Record<string, SessionEntry>;
+  sessionKey?: string;
+  status?: SessionsArchiveStatus;
+  olderThanMs?: number;
+  nowMs: number;
+}) {
+  const requestedKey = params.sessionKey?.trim();
+  const selectedEntries = Object.entries(params.store).filter(([key, entry]) => {
+    if (requestedKey) {
+      return key === requestedKey;
+    }
+    if (params.status && normalizeStatus(entry?.status) !== params.status) {
+      return false;
+    }
+    if (params.olderThanMs != null) {
+      const updatedAt = entry?.updatedAt;
+      if (!updatedAt || params.nowMs - updatedAt < params.olderThanMs) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  const actionByKey = new Map<
+    string,
+    { action: SessionArchiveAction; reason: SessionArchiveSkipReason | null }
+  >();
+  for (const [key, entry] of selectedEntries) {
+    const reason = resolveSkipReason({ key, entry, cfg: params.cfg });
+    actionByKey.set(key, {
+      action: reason ? "skip" : "archive",
+      reason,
+    });
+  }
+
+  const selectedStore = Object.fromEntries(selectedEntries);
+  const actionRows = toSessionDisplayRows(selectedStore).map((row) => {
+    const entry = params.store[row.key];
+    const action = actionByKey.get(row.key);
+    return {
+      ...row,
+      action: action?.action ?? "skip",
+      status: normalizeStatus(entry?.status),
+      reason: action?.reason ?? null,
+    } satisfies SessionArchiveActionRow;
+  });
+
+  const eligibleRows = actionRows.filter((row) => row.action === "archive");
+  const skippedRows = actionRows.filter((row) => row.action === "skip");
+  return {
+    actionRows,
+    eligibleRows,
+    skippedRows,
+  };
+}
+
+async function applyStoreArchive(params: {
+  target: SessionStoreTarget;
+  keys: string[];
+}): Promise<{ archived: number; transcriptFilesArchived: number }> {
+  const removed = await updateSessionStore(
+    params.target.storePath,
+    (store) => {
+      const deleted: Array<{
+        key: string;
+        sessionId?: string;
+        sessionFile?: string;
+      }> = [];
+      for (const key of params.keys) {
+        const entry = store[key];
+        if (!entry) {
+          continue;
+        }
+        deleted.push({
+          key,
+          sessionId: entry.sessionId,
+          sessionFile: entry.sessionFile,
+        });
+        delete store[key];
+      }
+      return deleted;
+    },
+    {
+      skipMaintenance: true,
+    },
+  );
+
+  let transcriptFilesArchived = 0;
+  for (const entry of removed) {
+    if (!entry.sessionId) {
+      continue;
+    }
+    transcriptFilesArchived += archiveSessionTranscripts({
+      sessionId: entry.sessionId,
+      storePath: params.target.storePath,
+      sessionFile: entry.sessionFile,
+      agentId: params.target.agentId,
+      reason: "deleted",
+      restrictToStoreDir: true,
+    }).length;
+  }
+
+  return {
+    archived: removed.length,
+    transcriptFilesArchived,
+  };
+}
+
+export function parseSessionsArchiveOlderThan(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return parseDurationMs(String(value).trim(), { defaultUnit: "d" });
+}
+
+export function resolveSessionsArchiveTargets(params: {
+  cfg: OpenClawConfig;
+  opts: SessionsArchiveOptions;
+}): SessionStoreTarget[] {
+  const requestedKey = params.opts.sessionKey?.trim();
+  const requestedKeyAgentId = requestedKey
+    ? parseAgentSessionKey(requestedKey)?.agentId
+    : undefined;
+  return resolveSessionStoreTargets(params.cfg, {
+    store: params.opts.store,
+    agent:
+      params.opts.agent ??
+      (!params.opts.store && !params.opts.allAgents && requestedKeyAgentId
+        ? requestedKeyAgentId
+        : undefined),
+    allAgents: params.opts.allAgents,
+  });
+}
+
+export async function runSessionsArchive(
+  opts: SessionsArchiveOptions,
+  cfg: OpenClawConfig = loadConfig(),
+): Promise<SessionsArchiveRunResult> {
+  const requestedKey = opts.sessionKey?.trim();
+  if (requestedKey && (opts.status || opts.olderThan)) {
+    throw new SessionsArchiveError(
+      "Do not combine a specific <session-key> with --status or --older-than.",
+    );
+  }
+  if (!requestedKey && !opts.status && !opts.olderThan) {
+    throw new SessionsArchiveError(
+      "Provide a <session-key> or at least one batch selector (--status/--older-than).",
+    );
+  }
+
+  let olderThanMs: number | undefined;
+  try {
+    olderThanMs = parseSessionsArchiveOlderThan(opts.olderThan);
+  } catch {
+    throw new SessionsArchiveError(
+      "--older-than must be a valid duration (for example: 24h, 7d, 1h30m)",
+    );
+  }
+
+  const targets = resolveSessionsArchiveTargets({ cfg, opts });
+  const nowMs = Date.now();
+  const stores: SessionsArchiveStoreResult[] = [];
+
+  for (const target of targets) {
+    const store = loadSessionStore(target.storePath, { skipCache: true });
+    const { actionRows, eligibleRows, skippedRows } = resolveStoreArchiveCandidates({
+      cfg,
+      store,
+      sessionKey: opts.sessionKey,
+      status: opts.status,
+      olderThanMs,
+      nowMs,
+    });
+    stores.push({
+      summary: {
+        agentId: target.agentId,
+        storePath: target.storePath,
+        dryRun: Boolean(opts.dryRun),
+        requestedKey: requestedKey || null,
+        status: opts.status ?? null,
+        olderThan: opts.olderThan?.trim() || null,
+        olderThanMs: olderThanMs ?? null,
+        totalEntries: Object.keys(store).length,
+        matched: actionRows.length,
+        eligible: eligibleRows.length,
+        skipped: skippedRows.length,
+        archived: opts.dryRun ? eligibleRows.length : 0,
+        transcriptFilesArchived: 0,
+        wouldMutate: eligibleRows.length > 0,
+      },
+      actionRows,
+      eligibleKeys: eligibleRows.map((row) => row.key),
+    });
+  }
+
+  if (requestedKey) {
+    const storesWithMatches = stores.filter((result) => result.summary.matched > 0);
+    if (storesWithMatches.length === 0) {
+      throw new SessionsArchiveError(
+        `Session ${opts.sessionKey} was not found in the selected session store(s).`,
+      );
+    }
+    if (storesWithMatches.length > 1) {
+      throw new SessionsArchiveError(
+        `Session ${opts.sessionKey} matched multiple session stores. Narrow the scope with --agent or --store.`,
+      );
+    }
+    if (!opts.dryRun && storesWithMatches[0]?.summary.eligible === 0) {
+      const blocked = storesWithMatches[0]?.actionRows[0];
+      throw new SessionsArchiveError(
+        blocked?.reason
+          ? `Cannot archive ${opts.sessionKey}: ${formatArchiveReason(blocked.reason)}.`
+          : `Cannot archive ${opts.sessionKey}.`,
+      );
+    }
+  }
+
+  if (!opts.dryRun) {
+    for (const result of stores) {
+      if (result.eligibleKeys.length === 0) {
+        continue;
+      }
+      const applied = await applyStoreArchive({
+        target: {
+          agentId: result.summary.agentId,
+          storePath: result.summary.storePath,
+        },
+        keys: result.eligibleKeys,
+      });
+      result.summary.archived = applied.archived;
+      result.summary.transcriptFilesArchived = applied.transcriptFilesArchived;
+      result.summary.dryRun = false;
+    }
+  }
+
+  return {
+    allAgents: Boolean(opts.allAgents),
+    requestedKey: requestedKey || null,
+    status: opts.status ?? null,
+    olderThan: opts.olderThan?.trim() || null,
+    stores,
+  };
+}

--- a/src/commands/sessions-archive.test.ts
+++ b/src/commands/sessions-archive.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  resolveSessionStoreTargets: vi.fn(),
+  loadSessionStore: vi.fn(),
+  updateSessionStore: vi.fn(),
+  archiveSessionTranscripts: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../config/sessions.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../config/sessions.js")>("../config/sessions.js");
+  return {
+    ...actual,
+    resolveSessionStoreTargets: mocks.resolveSessionStoreTargets,
+    loadSessionStore: mocks.loadSessionStore,
+    updateSessionStore: mocks.updateSessionStore,
+  };
+});
+
+vi.mock("../gateway/session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../gateway/session-utils.js")>(
+    "../gateway/session-utils.js",
+  );
+  return {
+    ...actual,
+    archiveSessionTranscripts: mocks.archiveSessionTranscripts,
+  };
+});
+
+import { sessionsArchiveCommand } from "./sessions-archive.js";
+
+function makeRuntime(): { runtime: RuntimeEnv; logs: string[]; errors: string[]; exits: number[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const exits: number[] = [];
+  return {
+    runtime: {
+      log: (msg: unknown) => logs.push(String(msg)),
+      error: (msg: unknown) => errors.push(String(msg)),
+      exit: (code?: number) => exits.push(code ?? 0),
+    },
+    logs,
+    errors,
+    exits,
+  };
+}
+
+describe("sessionsArchiveCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfig.mockReturnValue({
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }, { id: "lead" }] },
+    });
+    mocks.resolveSessionStoreTargets.mockReturnValue([
+      { agentId: "main", storePath: "/resolved/sessions.json" },
+    ]);
+    mocks.loadSessionStore.mockReturnValue({});
+    mocks.archiveSessionTranscripts.mockReturnValue([
+      "/resolved/id-1.jsonl.deleted.2026-03-28T06:00:00.000Z",
+    ]);
+    mocks.updateSessionStore.mockImplementation(
+      async (_storePath: string, mutator: (store: Record<string, SessionEntry>) => unknown) => {
+        const store: Record<string, SessionEntry> = {
+          "agent:main:task-1": {
+            sessionId: "id-1",
+            sessionFile: "id-1.jsonl",
+            updatedAt: Date.now() - 9 * 24 * 60 * 60 * 1000,
+            status: "done",
+          },
+        };
+        return await mutator(store);
+      },
+    );
+  });
+
+  it("derives the target agent from a specific agent-scoped session key", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:lead:subagent:abc": {
+        sessionId: "id-1",
+        updatedAt: 1,
+        status: "done",
+      },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsArchiveCommand(
+      {
+        sessionKey: "agent:lead:subagent:abc",
+        dryRun: true,
+        json: true,
+      },
+      runtime,
+    );
+
+    expect(mocks.resolveSessionStoreTargets).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ agent: "lead", allAgents: undefined }),
+    );
+    const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+    expect(payload.requestedKey).toBe("agent:lead:subagent:abc");
+    expect(payload.matched).toBe(1);
+    expect(payload.eligible).toBe(1);
+    expect(payload.archived).toBe(1);
+  });
+
+  it("reports skipped main and cron sessions in dry-run batch mode", async () => {
+    const now = Date.now();
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:done-old": {
+        sessionId: "done-old",
+        updatedAt: now - 9 * 24 * 60 * 60 * 1000,
+        status: "done",
+      },
+      "agent:main:main": {
+        sessionId: "main-id",
+        updatedAt: now - 9 * 24 * 60 * 60 * 1000,
+        status: "done",
+      },
+      "agent:main:cron:job-1:run:old": {
+        sessionId: "cron-old",
+        updatedAt: now - 9 * 24 * 60 * 60 * 1000,
+        status: "done",
+      },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsArchiveCommand(
+      {
+        status: "done",
+        olderThan: "7d",
+        dryRun: true,
+        json: true,
+      },
+      runtime,
+    );
+
+    const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+    expect(payload.matched).toBe(3);
+    expect(payload.eligible).toBe(1);
+    expect(payload.skipped).toBe(2);
+    expect(payload.archived).toBe(1);
+  });
+
+  it("archives only eligible sessions and skips maintenance on write", async () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:done-old": {
+        sessionId: "done-old",
+        sessionFile: "done-old.jsonl",
+        updatedAt: now - 9 * 24 * 60 * 60 * 1000,
+        status: "done",
+      },
+      "agent:main:active-old": {
+        sessionId: "active-old",
+        sessionFile: "active-old.jsonl",
+        updatedAt: now - 9 * 24 * 60 * 60 * 1000,
+        status: "running",
+      },
+    };
+    mocks.loadSessionStore.mockReturnValue(store);
+    mocks.updateSessionStore.mockImplementation(
+      async (
+        _storePath: string,
+        mutator: (store: Record<string, SessionEntry>) => unknown,
+        opts?: { skipMaintenance?: boolean },
+      ) => {
+        expect(opts).toEqual(expect.objectContaining({ skipMaintenance: true }));
+        return await mutator(store);
+      },
+    );
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsArchiveCommand(
+      {
+        olderThan: "7d",
+        json: true,
+      },
+      runtime,
+    );
+
+    const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+    expect(payload.archived).toBe(1);
+    expect(payload.skipped).toBe(1);
+    expect(store["agent:main:done-old"]).toBeUndefined();
+    expect(store["agent:main:active-old"]).toBeDefined();
+    expect(mocks.archiveSessionTranscripts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "done-old",
+        sessionFile: "done-old.jsonl",
+        reason: "deleted",
+        restrictToStoreDir: true,
+      }),
+    );
+  });
+
+  it("rejects non-dry-run attempts to archive the main session", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:main": {
+        sessionId: "main-id",
+        updatedAt: 1,
+        status: "done",
+      },
+    });
+
+    const { runtime, errors, exits } = makeRuntime();
+    await sessionsArchiveCommand(
+      {
+        sessionKey: "agent:main:main",
+      },
+      runtime,
+    );
+
+    expect(errors[0]).toContain("Cannot archive agent:main:main: protected main session.");
+    expect(exits).toEqual([1]);
+    expect(mocks.updateSessionStore).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/sessions-archive.ts
+++ b/src/commands/sessions-archive.ts
@@ -1,0 +1,176 @@
+import { loadConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { isRich, theme } from "../terminal/theme.js";
+import {
+  formatArchiveReason,
+  runSessionsArchive,
+  type SessionArchiveAction,
+  type SessionArchiveActionRow,
+  type SessionArchiveSkipReason,
+  type SessionArchiveSummary,
+  type SessionsArchiveOptions,
+} from "./sessions-archive-core.js";
+import {
+  formatSessionAgeCell,
+  formatSessionKeyCell,
+  formatSessionModelCell,
+  resolveSessionDisplayDefaults,
+  resolveSessionDisplayModel,
+  SESSION_AGE_PAD,
+  SESSION_KEY_PAD,
+  SESSION_MODEL_PAD,
+} from "./sessions-table.js";
+
+export type SessionsArchiveCommandOptions = SessionsArchiveOptions & {
+  json?: boolean;
+};
+
+const ACTION_PAD = 8;
+const STATUS_PAD = 9;
+const REASON_PAD = 22;
+
+function formatArchiveActionCell(action: SessionArchiveAction, rich: boolean): string {
+  const label = action.padEnd(ACTION_PAD);
+  if (!rich) {
+    return label;
+  }
+  return action === "archive" ? theme.success(label) : theme.warn(label);
+}
+
+function formatArchiveStatusCell(status: string | null, rich: boolean): string {
+  const label = (status ?? "unknown").padEnd(STATUS_PAD);
+  if (!rich) {
+    return label;
+  }
+  if (status === "done") {
+    return theme.success(label);
+  }
+  if (status === "killed" || status === "timeout") {
+    return theme.warn(label);
+  }
+  if (status === "running" || status === "active") {
+    return theme.error(label);
+  }
+  return theme.muted(label);
+}
+
+function formatArchiveReasonCell(reason: SessionArchiveSkipReason | null, rich: boolean): string {
+  const label = formatArchiveReason(reason).padEnd(REASON_PAD);
+  if (!rich) {
+    return label;
+  }
+  return reason ? theme.warn(label) : theme.muted(label);
+}
+
+function renderStoreArchivePlan(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  summary: SessionArchiveSummary;
+  actionRows: SessionArchiveActionRow[];
+  runtime: RuntimeEnv;
+  showAgentHeader: boolean;
+  displayDefaults: ReturnType<typeof resolveSessionDisplayDefaults>;
+}) {
+  const rich = isRich();
+  if (params.showAgentHeader) {
+    params.runtime.log(`Agent: ${params.summary.agentId}`);
+  }
+  params.runtime.log(`Session store: ${params.summary.storePath}`);
+  if (params.summary.requestedKey) {
+    params.runtime.log(`Requested session: ${params.summary.requestedKey}`);
+  } else {
+    if (params.summary.status) {
+      params.runtime.log(`Status filter: ${params.summary.status}`);
+    }
+    if (params.summary.olderThan) {
+      params.runtime.log(`Age filter: older than ${params.summary.olderThan}`);
+    }
+  }
+  params.runtime.log(`Matched sessions: ${params.summary.matched}`);
+  params.runtime.log(
+    `${params.summary.dryRun ? "Would archive" : "Archived"}: ${params.summary.archived}`,
+  );
+  params.runtime.log(`Skipped protected/active sessions: ${params.summary.skipped}`);
+  params.runtime.log(`Transcript files archived: ${params.summary.transcriptFilesArchived}`);
+  if (params.actionRows.length === 0) {
+    params.runtime.log("No sessions matched the requested selectors.");
+    return;
+  }
+
+  params.runtime.log("");
+  params.runtime.log(params.summary.dryRun ? "Planned session actions:" : "Session actions:");
+  const header = [
+    "Action".padEnd(ACTION_PAD),
+    "Status".padEnd(STATUS_PAD),
+    "Key".padEnd(SESSION_KEY_PAD),
+    "Age".padEnd(SESSION_AGE_PAD),
+    "Model".padEnd(SESSION_MODEL_PAD),
+    "Reason".padEnd(REASON_PAD),
+  ].join(" ");
+  params.runtime.log(rich ? theme.heading(header) : header);
+  for (const actionRow of params.actionRows) {
+    const model = resolveSessionDisplayModel(params.cfg, actionRow, params.displayDefaults);
+    const line = [
+      formatArchiveActionCell(actionRow.action, rich),
+      formatArchiveStatusCell(actionRow.status, rich),
+      formatSessionKeyCell(actionRow.key, rich),
+      formatSessionAgeCell(actionRow.updatedAt, rich),
+      formatSessionModelCell(model, rich),
+      formatArchiveReasonCell(actionRow.reason, rich),
+    ].join(" ");
+    params.runtime.log(line.trimEnd());
+  }
+}
+
+export async function sessionsArchiveCommand(
+  opts: SessionsArchiveCommandOptions,
+  runtime: RuntimeEnv,
+) {
+  const cfg = loadConfig();
+  const displayDefaults = resolveSessionDisplayDefaults(cfg);
+
+  let result;
+  try {
+    result = await runSessionsArchive(opts, cfg);
+  } catch (error) {
+    runtime.error(error instanceof Error ? error.message : String(error));
+    runtime.exit(1);
+    return;
+  }
+
+  if (opts.json) {
+    if (result.stores.length === 1) {
+      runtime.log(JSON.stringify(result.stores[0]?.summary ?? {}, null, 2));
+      return;
+    }
+    runtime.log(
+      JSON.stringify(
+        {
+          allAgents: result.allAgents,
+          dryRun: Boolean(opts.dryRun),
+          requestedKey: result.requestedKey,
+          status: result.status,
+          olderThan: result.olderThan,
+          stores: result.stores.map((store) => store.summary),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  for (let i = 0; i < result.stores.length; i += 1) {
+    const store = result.stores[i];
+    if (i > 0) {
+      runtime.log("");
+    }
+    renderStoreArchivePlan({
+      cfg,
+      summary: store.summary,
+      actionRows: store.actionRows,
+      runtime,
+      showAgentHeader: result.stores.length > 1,
+      displayDefaults,
+    });
+  }
+}

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -876,6 +876,38 @@ describe("agent event handler", () => {
     expect(payload.sessionKey).toBe("session-from-event");
   });
 
+  it("uses explicit sessionKey on thinking events so webchat can filter live reasoning", () => {
+    const { broadcast, nodeSendToSession, handler } = createHarness({
+      resolveSessionKeyForRun: () => undefined,
+    });
+
+    handler({
+      runId: "run-thinking-session-key",
+      seq: 1,
+      stream: "thinking",
+      ts: 1_234,
+      sessionKey: "session-thinking",
+      data: {
+        text: "Reasoning:\n_Checking files_",
+        delta: "Reasoning:\n_Checking files_",
+      },
+    });
+
+    const payload = expectSingleAgentBroadcastPayload(broadcast);
+    expect(payload.sessionKey).toBe("session-thinking");
+    expect(payload.stream).toBe("thinking");
+
+    const nodeCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
+    expect(nodeCalls).toHaveLength(1);
+    expect(nodeCalls[0]?.[0]).toBe("session-thinking");
+    expect(nodeCalls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        stream: "thinking",
+        sessionKey: "session-thinking",
+      }),
+    );
+  });
+
   it("remaps chat-linked tool runId for non-full verbose payloads", () => {
     const { broadcastToConnIds, chatRunState, toolEventRecipients, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-tool-remap",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -737,7 +737,7 @@ export function createAgentEventHandler({
       // messages to messaging surfaces (Telegram, Discord, etc.).
       const recipients = toolEventRecipients.get(evt.runId);
       if (recipients && recipients.size > 0) {
-        broadcastToConnIds("agent", toolPayload, recipients);
+        _broadcastToConnIds("agent", toolPayload, recipients);
       }
       // Session subscribers power operator UIs that attach to an existing
       // in-flight session after the run has already started. Those clients do
@@ -747,7 +747,9 @@ export function createAgentEventHandler({
       if (sessionKey) {
         const sessionSubscribers = sessionEventSubscribers.getAll();
         if (sessionSubscribers.size > 0) {
-          broadcastToConnIds("session.tool", toolPayload, sessionSubscribers, { dropIfSlow: true });
+          _broadcastToConnIds("session.tool", toolPayload, sessionSubscribers, {
+            dropIfSlow: true,
+          });
         }
       }
       // Also broadcast tool events to all connected clients so sub-agent tool
@@ -824,7 +826,7 @@ export function createAgentEventHandler({
       void persistGatewaySessionLifecycleEvent({ sessionKey, event: evt }).catch(() => undefined);
       const sessionEventConnIds = sessionEventSubscribers.getAll();
       if (sessionEventConnIds.size > 0) {
-        broadcastToConnIds(
+        _broadcastToConnIds(
           "sessions.changed",
           {
             sessionKey,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -41,8 +41,8 @@ import {
   parseMessageWithAttachments,
 } from "../chat-attachments.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
-import { ADMIN_SCOPE } from "../method-scopes.js";
 import { saveInlineFileAttachment } from "../file-upload-save.js";
+import { ADMIN_SCOPE } from "../method-scopes.js";
 import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,


### PR DESCRIPTION
## Summary
- add `openclaw sessions archive` for exact-session and filtered batch archival
- add a shared archive core and expose it to agents via the `sessions_archive` tool
- protect active, main, and cron sessions while keeping archiving manual-only and maintenance-free

## Testing
- pnpm exec vitest run src/commands/sessions-archive.test.ts src/cli/program/register.status-health-sessions.test.ts src/agents/tools/sessions-archive-tool.test.ts src/agents/openclaw-tools.sessions.test.ts src/agents/tool-mutation.test.ts src/agents/pi-tools.policy.test.ts src/agents/system-prompt.test.ts
- pnpm build
- git commit hook (`pnpm check`)
- manual CLI smoke test archiving a temp done session while preserving `agent:main:main`

Closes #22