### PR TITLE
feat(channels): register webchat as deliverable channel for heartbeat/cron delivery

### DIFF
--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -94,12 +94,17 @@ export async function deliverAgentCommandResult(params: {
   });
   let deliveryChannel = deliveryPlan.resolvedChannel;
   const explicitChannelHint = (opts.replyChannel ?? opts.channel)?.trim();
+  // When the delivery channel is webchat, check if the webchat channel plugin
+  // is registered (gateway running). If not, try to resolve a real external channel.
   if (deliver && isInternalMessageChannel(deliveryChannel) && !explicitChannelHint) {
-    try {
-      const selection = await resolveMessageChannelSelection({ cfg });
-      deliveryChannel = selection.channel;
-    } catch {
-      // Keep the internal channel marker; error handling below reports the failure.
+    const webchatPlugin = getChannelPlugin(deliveryChannel);
+    if (!webchatPlugin?.outbound) {
+      try {
+        const selection = await resolveMessageChannelSelection({ cfg });
+        deliveryChannel = selection.channel;
+      } catch {
+        // Keep the internal channel marker; error handling below reports the failure.
+      }
     }
   }
   const effectiveDeliveryPlan =
@@ -110,12 +115,10 @@ export async function deliverAgentCommandResult(params: {
           resolvedChannel: deliveryChannel,
         };
   // Channel docking: delivery channels are resolved via plugin registry.
-  const deliveryPlugin = !isInternalMessageChannel(deliveryChannel)
-    ? getChannelPlugin(normalizeChannelId(deliveryChannel) ?? deliveryChannel)
-    : undefined;
+  // Include webchat when the webchat channel plugin is registered.
+  const deliveryPlugin = getChannelPlugin(normalizeChannelId(deliveryChannel) ?? deliveryChannel);
 
-  const isDeliveryChannelKnown =
-    isInternalMessageChannel(deliveryChannel) || Boolean(deliveryPlugin);
+  const isDeliveryChannelKnown = Boolean(deliveryPlugin);
 
   const targetMode =
     opts.deliveryTargetMode ??
@@ -151,7 +154,10 @@ export async function deliverAgentCommandResult(params: {
   };
 
   if (deliver) {
-    if (isInternalMessageChannel(deliveryChannel)) {
+    // Webchat is deliverable when the webchat channel plugin is registered (gateway running).
+    const isWebchatDeliverable =
+      isInternalMessageChannel(deliveryChannel) && Boolean(deliveryPlugin?.outbound);
+    if (isInternalMessageChannel(deliveryChannel) && !isWebchatDeliverable) {
       const err = new Error(
         "delivery channel is required: pass --channel/--reply-channel or use a main session with a previous channel",
       );
@@ -215,7 +221,11 @@ export async function deliverAgentCommandResult(params: {
       logPayload(payload);
     }
   }
-  if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {
+  // Deliver to any known channel, including webchat when its plugin is active.
+  const canDeliverToChannel =
+    Boolean(deliveryChannel) &&
+    (!isInternalMessageChannel(deliveryChannel) || Boolean(deliveryPlugin?.outbound));
+  if (deliver && canDeliverToChannel) {
     if (deliveryTarget) {
       await deliverOutboundPayloads({
         cfg,

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -17,6 +17,7 @@ import { synologyChatPlugin } from "../../../extensions/synology-chat/index.js";
 import { telegramPlugin, setTelegramRuntime } from "../../../extensions/telegram/index.js";
 import { telegramSetupPlugin } from "../../../extensions/telegram/setup-entry.js";
 import { zaloPlugin } from "../../../extensions/zalo/index.js";
+import { webchatPlugin } from "../webchat/index.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
 
 export const bundledChannelPlugins = [
@@ -32,6 +33,7 @@ export const bundledChannelPlugins = [
   slackPlugin,
   synologyChatPlugin,
   telegramPlugin,
+  webchatPlugin,
   zaloPlugin,
 ] as ChannelPlugin[];
 

--- a/src/channels/webchat/index.ts
+++ b/src/channels/webchat/index.ts
@@ -1,0 +1,8 @@
+export { webchatPlugin } from "./plugin.js";
+export {
+  registerWebchatBroadcast,
+  getWebchatBroadcast,
+  setWebchatConnectedClients,
+  hasConnectedWebchatClients,
+  isWebchatOutboundAvailable,
+} from "./outbound-sender.js";

--- a/src/channels/webchat/outbound-sender.ts
+++ b/src/channels/webchat/outbound-sender.ts
@@ -1,0 +1,69 @@
+/**
+ * Webchat outbound sender — global singleton that the gateway server registers
+ * its broadcast function with so the webchat channel plugin can deliver
+ * proactive messages (heartbeats, cron results, etc.) to connected WebSocket
+ * clients.
+ *
+ * The gateway calls `registerWebchatBroadcast()` on startup, and the webchat
+ * channel plugin calls `getWebchatBroadcast()` at delivery time.
+ */
+
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+
+export type WebchatBroadcastFn = (event: string, payload: unknown) => void;
+
+type WebchatOutboundState = {
+  broadcast: WebchatBroadcastFn | null;
+  /** Number of currently connected webchat clients (updated by the gateway). */
+  connectedClients: number;
+};
+
+const WEBCHAT_OUTBOUND_STATE_KEY = Symbol.for("openclaw.webchat.outboundState");
+
+const state = resolveGlobalSingleton<WebchatOutboundState>(WEBCHAT_OUTBOUND_STATE_KEY, () => ({
+  broadcast: null,
+  connectedClients: 0,
+}));
+
+/**
+ * Register the gateway's broadcast function for webchat outbound delivery.
+ * Called once during gateway startup.
+ */
+export function registerWebchatBroadcast(broadcast: WebchatBroadcastFn): () => void {
+  state.broadcast = broadcast;
+  return () => {
+    if (state.broadcast === broadcast) {
+      state.broadcast = null;
+    }
+  };
+}
+
+/**
+ * Get the registered broadcast function, or null if the gateway is not running.
+ */
+export function getWebchatBroadcast(): WebchatBroadcastFn | null {
+  return state.broadcast;
+}
+
+/**
+ * Update the count of connected webchat clients.
+ * Called by the gateway when clients connect/disconnect.
+ */
+export function setWebchatConnectedClients(count: number): void {
+  state.connectedClients = Math.max(0, count);
+}
+
+/**
+ * Check if any webchat clients are currently connected.
+ */
+export function hasConnectedWebchatClients(): boolean {
+  return state.connectedClients > 0;
+}
+
+/**
+ * Check if webchat outbound delivery is available.
+ * Requires the gateway to be running (broadcast registered).
+ */
+export function isWebchatOutboundAvailable(): boolean {
+  return state.broadcast !== null;
+}

--- a/src/channels/webchat/plugin.ts
+++ b/src/channels/webchat/plugin.ts
@@ -1,0 +1,146 @@
+/**
+ * Webchat channel plugin — registers the gateway's built-in webchat (WebSocket)
+ * interface as a deliverable channel so heartbeats, cron results, and proactive
+ * messages can reach connected clients (e.g. the Talkyn voice app).
+ *
+ * Unlike external channel plugins (Telegram, Discord, etc.), webchat delivery
+ * goes through the gateway's WebSocket broadcast system. The gateway registers
+ * its broadcast function via `registerWebchatBroadcast()` on startup.
+ */
+
+import type { OpenClawConfig } from "../../config/config.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
+import type { ChannelOutboundAdapter } from "../plugins/types.adapters.js";
+import type { ChannelPlugin } from "../plugins/types.plugin.js";
+import {
+  getWebchatBroadcast,
+  hasConnectedWebchatClients,
+  isWebchatOutboundAvailable,
+} from "./outbound-sender.js";
+
+// ── Config adapter ──
+
+const WEBCHAT_ACCOUNT_ID = "default";
+
+const webchatConfigAdapter = {
+  listAccountIds: (_cfg: OpenClawConfig) => {
+    // Webchat is always "configured" when the gateway is running —
+    // there's no external token or setup needed.
+    return isWebchatOutboundAvailable() ? [WEBCHAT_ACCOUNT_ID] : [];
+  },
+  resolveAccount: (_cfg: OpenClawConfig, _accountId?: string | null) => ({
+    accountId: WEBCHAT_ACCOUNT_ID,
+    enabled: true,
+  }),
+  isEnabled: () => true,
+  isConfigured: () => isWebchatOutboundAvailable(),
+};
+
+// ── Outbound adapter ──
+
+let messageSeq = 0;
+
+const webchatOutboundAdapter: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  resolveTarget: ({ to }) => {
+    // Webchat delivery doesn't use traditional "to" targets.
+    // Any non-empty value is fine — we broadcast to all connected clients.
+    const target = to?.trim() || "webchat";
+    return { ok: true, to: target };
+  },
+  sendText: async (ctx) => {
+    const broadcast = getWebchatBroadcast();
+    if (!broadcast) {
+      throw new Error("Webchat broadcast not available — gateway not running");
+    }
+    const id = `webchat-proactive-${Date.now()}-${++messageSeq}`;
+    // Use the same chat event format the gateway uses for normal replies
+    // so connected webchat/voice app clients can render the message.
+    broadcast("chat", {
+      runId: id,
+      sessionKey: "",
+      seq: 1,
+      state: "final",
+      message: {
+        role: "assistant",
+        content: ctx.text,
+      },
+    });
+    return {
+      channel: INTERNAL_MESSAGE_CHANNEL,
+      messageId: id,
+    };
+  },
+  sendMedia: async (ctx) => {
+    const broadcast = getWebchatBroadcast();
+    if (!broadcast) {
+      throw new Error("Webchat broadcast not available — gateway not running");
+    }
+    const id = `webchat-proactive-${Date.now()}-${++messageSeq}`;
+    const text = ctx.text || "";
+    const mediaNote = ctx.mediaUrl ? `\n\n[media: ${ctx.mediaUrl}]` : "";
+    broadcast("chat", {
+      runId: id,
+      sessionKey: "",
+      seq: 1,
+      state: "final",
+      message: {
+        role: "assistant",
+        content: `${text}${mediaNote}`,
+      },
+    });
+    return {
+      channel: INTERNAL_MESSAGE_CHANNEL,
+      messageId: id,
+    };
+  },
+};
+
+// ── Heartbeat adapter ──
+
+const webchatHeartbeatAdapter = {
+  checkReady: async () => {
+    if (!isWebchatOutboundAvailable()) {
+      return { ok: false, reason: "gateway-not-running" };
+    }
+    if (!hasConnectedWebchatClients()) {
+      return { ok: false, reason: "no-connected-clients" };
+    }
+    return { ok: true, reason: "ok" };
+  },
+  resolveRecipients: () => ({
+    recipients: ["webchat"],
+    source: "webchat-broadcast",
+  }),
+};
+
+// ── Plugin definition ──
+
+export const webchatPlugin: ChannelPlugin = {
+  id: INTERNAL_MESSAGE_CHANNEL,
+  meta: {
+    id: INTERNAL_MESSAGE_CHANNEL,
+    label: "WebChat",
+    selectionLabel: "WebChat (Gateway UI)",
+    docsPath: "/channels/webchat",
+    blurb: "built-in gateway WebSocket interface for web and voice app clients.",
+    order: 100, // After all external channels
+    showConfigured: false,
+  },
+  capabilities: {
+    chatTypes: ["direct"],
+    media: false,
+    polls: false,
+    reactions: false,
+    edit: false,
+    unsend: false,
+    reply: false,
+    effects: false,
+    threads: false,
+    groupManagement: false,
+    nativeCommands: false,
+  },
+  config: webchatConfigAdapter,
+  outbound: webchatOutboundAdapter,
+  heartbeat: webchatHeartbeatAdapter,
+};

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -6,6 +6,7 @@ import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import { registerWebchatBroadcast } from "../channels/webchat/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { isRestartEnabled } from "../config/commands.js";
@@ -744,6 +745,11 @@ export async function startGatewayServer(
   const hasMobileNodeConnected = () => hasConnectedMobileNode(nodeRegistry);
   applyGatewayLaneConcurrency(cfgAtStart);
 
+  // Register the gateway's broadcast function for webchat channel delivery.
+  // This enables heartbeats, cron results, and proactive messages to reach
+  // connected WebSocket clients (e.g. the Talkyn voice app).
+  const disposeWebchatBroadcast = registerWebchatBroadcast(broadcast);
+
   let cronState = buildGatewayCronService({
     cfg: cfgAtStart,
     deps,
@@ -1348,6 +1354,7 @@ export async function startGatewayServer(
       stopModelPricingRefresh();
       channelHealthMonitor?.stop();
       clearSecretsRuntimeSnapshot();
+      disposeWebchatBroadcast();
       await close(opts);
     },
   };

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WebSocket, WebSocketServer } from "ws";
+import { setWebchatConnectedClients } from "../../channels/webchat/index.js";
 import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { removeRemoteNodeInfo } from "../../infra/skills-remote.js";
 import { upsertPresence } from "../../infra/system-presence.js";
@@ -113,6 +114,11 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     buildRequestContext,
   } = params;
   const originCheckMetrics: WsOriginCheckMetrics = { hostHeaderFallbackAccepted: 0 };
+  let webchatClientCount = 0;
+  const updateWebchatClientCount = (delta: number) => {
+    webchatClientCount = Math.max(0, webchatClientCount + delta);
+    setWebchatConnectedClients(webchatClientCount);
+  };
 
   wss.on("connection", (socket, upgradeReq) => {
     let client: GatewayWsClient | null = null;
@@ -188,6 +194,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       clearTimeout(handshakeTimer);
       if (client) {
         clients.delete(client);
+        if (isWebchatClient(client.connect.client)) {
+          updateWebchatClientCount(-1);
+        }
       }
       try {
         socket.close(code, reason);
@@ -315,6 +324,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       setClient: (next) => {
         client = next;
         clients.add(next);
+        if (isWebchatClient(next.connect.client)) {
+          updateWebchatClientCount(1);
+        }
       },
       setHandshakeState: (next) => {
         handshakeState = next;

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -189,13 +189,22 @@ export function resolveOutboundTarget(params: {
   accountId?: string | null;
   mode?: ChannelOutboundTargetMode;
 }): OutboundTargetResolution {
+  // Webchat was historically rejected here because it had no delivery plugin.
+  // Now that it has one, only reject when used from the CLI (no plugin available).
   if (params.channel === INTERNAL_MESSAGE_CHANNEL) {
-    return {
-      ok: false,
-      error: new Error(
-        `Delivering to WebChat is not supported via \`${formatCliCommand("openclaw agent")}\`; use WhatsApp/Telegram or run with --deliver=false.`,
-      ),
-    };
+    const webchatOutboundPlugin = resolveOutboundChannelPlugin({
+      channel: params.channel,
+      cfg: params.cfg,
+    });
+    if (!webchatOutboundPlugin?.outbound) {
+      return {
+        ok: false,
+        error: new Error(
+          `Delivering to WebChat is not supported via \`${formatCliCommand("openclaw agent")}\`; use WhatsApp/Telegram or run with --deliver=false.`,
+        ),
+      };
+    }
+    // Fall through to normal plugin-based resolution below.
   }
 
   const plugin = resolveOutboundChannelPlugin({


### PR DESCRIPTION
## Summary

Add a webchat channel plugin that enables the gateway's built-in WebSocket interface to receive proactive messages (heartbeats, cron results, etc.).

Previously, webchat was treated as an internal-only channel with no delivery capabilities. Heartbeat and cron delivery would fail with `Channel is required (no configured channels detected)` when webchat was the only interface.

## Changes

- **New webchat channel plugin** (`src/channels/webchat/`) with:
  - Config adapter: auto-configured when gateway is running
  - Outbound adapter: delivers via gateway WebSocket broadcast
  - Heartbeat adapter: checks for connected webchat clients
- Global singleton for webchat broadcast registration
- Gateway registers broadcast function on startup, tracks webchat client count
- Updated delivery pipeline to accept webchat as deliverable when plugin active
- Updated outbound target resolution to not reject webchat when plugin available

The webchat plugin follows the same `ChannelPlugin` contract as Telegram, Discord, etc. but delivers through the gateway's existing broadcast mechanism instead of an external API.

## Companion PR

The frontend counterpart (identifying as webchat client + rendering proactive messages) is in lbr88/talkyn-native.

Refs: lbr88/talkyn-native#233