### PR TITLE
fix(gateway): ensure slow consumers receive complete streaming text before final

### DIFF
--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -21,6 +21,23 @@ const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "session.tool": [READ_SCOPE],
 };
 
+// ── dropIfSlow diagnostics ──
+// Track consecutive drops per connection and rate-limit warnings to avoid
+// flooding logs when a client is persistently slow.
+const DROP_WARN_INTERVAL_MS = 5_000;
+type DropIfSlowState = {
+  /** Running count of consecutive chat events dropped for this connection. */
+  consecutiveDrops: number;
+  /** Timestamp of last warning log for this connection. */
+  lastWarnAt: number;
+};
+const dropIfSlowStates = new Map<string, DropIfSlowState>();
+
+/** Clean up tracking state when a connection closes. */
+export function clearDropIfSlowState(connId: string): void {
+  dropIfSlowStates.delete(connId);
+}
+
 export type GatewayBroadcastStateVersion = {
   presence?: number;
   health?: number;
@@ -108,6 +125,24 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       const slow = c.socket.bufferedAmount > MAX_BUFFERED_BYTES;
       if (slow && opts?.dropIfSlow) {
+        // Track the drop and emit a rate-limited warning so operators can
+        // diagnose streaming issues caused by slow consumers.
+        const now = Date.now();
+        let state = dropIfSlowStates.get(c.connId);
+        if (!state) {
+          state = { consecutiveDrops: 0, lastWarnAt: 0 };
+          dropIfSlowStates.set(c.connId, state);
+        }
+        state.consecutiveDrops += 1;
+        if (now - state.lastWarnAt >= DROP_WARN_INTERVAL_MS) {
+          state.lastWarnAt = now;
+          logWs("out", "drop-slow", {
+            connId: c.connId,
+            event,
+            bufferedMB: Math.round(c.socket.bufferedAmount / (1024 * 1024)),
+            consecutiveDrops: state.consecutiveDrops,
+          });
+        }
         continue;
       }
       if (slow) {
@@ -117,6 +152,11 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
           /* ignore */
         }
         continue;
+      }
+      // Reset drop counter on successful send
+      const existingState = dropIfSlowStates.get(c.connId);
+      if (existingState && existingState.consecutiveDrops > 0) {
+        existingState.consecutiveDrops = 0;
       }
       try {
         c.socket.send(frame);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1011,4 +1011,126 @@ describe("agent event handler", () => {
       "Disk usage crossed 95 percent on /data and needs cleanup now.",
     );
   });
+
+  it("pre-final flush does NOT use dropIfSlow so slow consumers get complete text", () => {
+    let now = 20_000;
+    const { broadcast, chatRunState, handler, nowSpy } = createHarness({
+      now,
+      resolveSessionKeyForRun: () => "session-slow",
+    });
+
+    chatRunState.registry.add("run-slow", {
+      sessionKey: "session-slow",
+      clientRunId: "client-slow",
+    });
+    registerAgentRunContext("run-slow", { sessionKey: "session-slow" });
+
+    // First delta — passes 150ms throttle (last = 0)
+    handler({
+      runId: "run-slow",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello" },
+    });
+
+    const chatCallsAfterDelta = chatBroadcastCalls(broadcast);
+    expect(chatCallsAfterDelta).toHaveLength(1);
+    // Regular delta uses dropIfSlow
+    expect(chatCallsAfterDelta[0]?.[2]).toEqual({ dropIfSlow: true });
+
+    // Throttled update (within 150ms)
+    now = 20_050;
+    nowSpy?.mockReturnValue(now);
+    handler({
+      runId: "run-slow",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world complete response" },
+    });
+
+    // Should still be 1 chat call (throttled)
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+
+    // Now lifecycle:end fires — triggers pre-final flush + final
+    now = 20_200;
+    nowSpy?.mockReturnValue(now);
+    emitLifecycleEnd(handler, "run-slow", 3);
+
+    const allChatCalls = chatBroadcastCalls(broadcast);
+    // Expect 3 calls: initial delta, pre-final flush, final
+    expect(allChatCalls).toHaveLength(3);
+
+    // Pre-final flush (second call) must NOT have dropIfSlow
+    const flushCall = allChatCalls[1];
+    expect(flushCall?.[2]).toBeUndefined(); // no opts = no dropIfSlow
+
+    // The flush payload should contain the complete buffered text
+    const flushPayload = flushCall?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(flushPayload.state).toBe("delta");
+    expect(flushPayload.message?.content?.[0]?.text).toBe("Hello world complete response");
+
+    // Final (third call) should also not have dropIfSlow
+    const finalCall = allChatCalls[2];
+    expect(finalCall?.[2]).toBeUndefined();
+
+    nowSpy?.mockRestore();
+    resetAgentRunContextForTest();
+  });
+
+  it("tool-start flush still uses dropIfSlow", () => {
+    let now = 30_000;
+    const { broadcast, chatRunState, handler, nowSpy, toolEventRecipients } = createHarness({
+      now,
+      resolveSessionKeyForRun: () => "session-tool-drop",
+    });
+
+    chatRunState.registry.add("run-tool-drop", {
+      sessionKey: "session-tool-drop",
+      clientRunId: "client-tool-drop",
+    });
+    registerAgentRunContext("run-tool-drop", { sessionKey: "session-tool-drop" });
+    toolEventRecipients.add("run-tool-drop", "conn-1");
+
+    // First delta
+    handler({
+      runId: "run-tool-drop",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Thinking..." },
+    });
+
+    // Throttled update
+    now = 30_050;
+    nowSpy?.mockReturnValue(now);
+    handler({
+      runId: "run-tool-drop",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Thinking... let me check" },
+    });
+
+    // Tool start triggers flush
+    handler({
+      runId: "run-tool-drop",
+      seq: 3,
+      stream: "tool",
+      ts: Date.now(),
+      data: { phase: "start", name: "read", toolCallId: "t-drop-1" },
+    });
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(2);
+    // Tool-start flush should still use dropIfSlow
+    expect(chatCalls[1]?.[2]).toEqual({ dropIfSlow: true });
+
+    nowSpy?.mockRestore();
+    resetAgentRunContextForTest();
+  });
 });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -571,6 +571,7 @@ export function createAgentEventHandler({
     clientRunId: string,
     sourceRunId: string,
     seq: number,
+    opts?: { dropIfSlow?: boolean },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId);
     const shouldSuppressSilentLeadFragment = isSilentReplyLeadFragment(text);
@@ -604,7 +605,7 @@ export function createAgentEventHandler({
         timestamp: now,
       },
     };
-    broadcast("chat", flushPayload, { dropIfSlow: true });
+    broadcast("chat", flushPayload, opts?.dropIfSlow ? { dropIfSlow: true } : undefined);
     nodeSendToSession(sessionKey, "chat", flushPayload);
     chatRunState.deltaLastBroadcastLen.set(clientRunId, text.length);
     chatRunState.deltaSentAt.set(clientRunId, now);
@@ -729,7 +730,9 @@ export function createAgentEventHandler({
       // Flush pending assistant text before tool-start events so clients can
       // render complete pre-tool text above tool cards (not truncated by delta throttle).
       if (toolPhase === "start" && isControlUiVisible && sessionKey && !isAborted) {
-        flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
+        flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq, {
+          dropIfSlow: true,
+        });
       }
       // Always broadcast tool events to registered WS recipients with
       // tool-events capability, regardless of verboseLevel. The verbose

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -10,6 +10,7 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { isLoopbackAddress } from "../net.js";
+import { clearDropIfSlowState } from "../server-broadcast.js";
 import { getHandshakeTimeoutMs } from "../server-constants.js";
 import { cleanupFileUploadManager } from "../server-methods/file-upload.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
@@ -264,6 +265,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
       // Clean up any in-progress file uploads for this connection.
       cleanupFileUploadManager(connId);
+      // Clean up dropIfSlow diagnostics state for this connection.
+      clearDropIfSlowState(connId);
       // Clean up any in-progress voice turns owned by this connection.
       const clearedVoiceTurns = clearVoiceTurnsByConnId(connId);
       if (clearedVoiceTurns.length > 0) {


### PR DESCRIPTION
Fixes lbr88/talkyn-native#247

## Problem

Desktop client (Win32, WebSocket connection over WAN) received **zero chat deltas** for 30+ minutes while phone client (same gateway, same session) streamed normally. Messages appeared **fully formed with no incremental streaming** on desktop.

## Root Cause

The pre-final delta flush used `dropIfSlow: true`, which silently skipped clients whose WebSocket send buffer exceeded `MAX_BUFFERED_BYTES` (50 MB).

When a client's connection is slower than the event throughput (e.g., desktop on WAN vs. phone on LAN), the WS send buffer grows. The 150 ms throttled chat deltas used `dropIfSlow: true`, so they were silently skipped when the buffer exceeded the threshold. The final event (without `dropIfSlow`) delivered the complete text at once, making messages appear to 'pop in' fully formed.

## Changes

1. **Pre-final flush no longer uses `dropIfSlow`** — clients who missed streaming deltas now receive the complete accumulated text as a catch-up delta before the final event
2. **Tool-start flush retains `dropIfSlow`** (non-critical, text continues after tool completes)
3. **Added rate-limited warning logs** when `dropIfSlow` triggers, with per-connection consecutive-drop tracking for diagnostics
4. **Clean up drop tracking state** on connection close

## Testing

- Added 2 new tests verifying pre-final flush behavior (28 tests pass)
- Existing test suite passes (1 pre-existing failure unrelated to this change)
- Manual verification: pre-final flush sends `broadcast('chat', payload)` with **no opts** (no `dropIfSlow`)

## Result

Slow consumers (high-latency connections, WAN) who miss streaming deltas due to buffer backpressure will now receive the complete text as a final delta before the `chat:final` event, ensuring they see the message content even if incremental streaming was dropped.