### PR TITLE
fix: allow webchat delivery in gateway agent handler

### DIFF
--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,6 +2,10 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
+export const DEFAULT_NESTED_AGENT_MAX_CONCURRENT = Math.max(
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+);
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;
 
@@ -19,4 +23,11 @@ export function resolveSubagentMaxConcurrent(cfg?: OpenClawConfig): number {
     return Math.max(1, Math.floor(raw));
   }
   return DEFAULT_SUBAGENT_MAX_CONCURRENT;
+}
+
+export function resolveNestedAgentMaxConcurrent(cfg?: OpenClawConfig): number {
+  if (!cfg) {
+    return DEFAULT_NESTED_AGENT_MAX_CONCURRENT;
+  }
+  return Math.max(resolveAgentMaxConcurrent(cfg), resolveSubagentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CommandLane } from "../process/lanes.js";
+
+const queueMocks = vi.hoisted(() => ({
+  setCommandLaneConcurrency: vi.fn(),
+}));
+
+vi.mock("../process/command-queue.js", () => ({
+  setCommandLaneConcurrency: queueMocks.setCommandLaneConcurrency,
+}));
+
+describe("applyGatewayLaneConcurrency", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    queueMocks.setCommandLaneConcurrency.mockReset();
+  });
+
+  it("applies default concurrency including the nested lane", async () => {
+    const { applyGatewayLaneConcurrency } = await import("./server-lanes.js");
+
+    applyGatewayLaneConcurrency({} as never);
+
+    expect(queueMocks.setCommandLaneConcurrency).toHaveBeenNthCalledWith(1, CommandLane.Cron, 1);
+    expect(queueMocks.setCommandLaneConcurrency).toHaveBeenNthCalledWith(2, CommandLane.Main, 4);
+    expect(queueMocks.setCommandLaneConcurrency).toHaveBeenNthCalledWith(
+      3,
+      CommandLane.Subagent,
+      8,
+    );
+    expect(queueMocks.setCommandLaneConcurrency).toHaveBeenNthCalledWith(4, CommandLane.Nested, 8);
+  });
+
+  it("sizes the nested lane to the larger of agent and subagent concurrency", async () => {
+    const { applyGatewayLaneConcurrency } = await import("./server-lanes.js");
+
+    applyGatewayLaneConcurrency({
+      cron: { maxConcurrentRuns: 2 },
+      agents: {
+        defaults: {
+          maxConcurrent: 6,
+          subagents: { maxConcurrent: 3 },
+        },
+      },
+    } as never);
+
+    expect(queueMocks.setCommandLaneConcurrency).toHaveBeenNthCalledWith(1, CommandLane.Cron, 2);
+    expect(queueMocks.setCommandLaneConcurrency).toHaveBeenNthCalledWith(2, CommandLane.Main, 6);
+    expect(queueMocks.setCommandLaneConcurrency).toHaveBeenNthCalledWith(
+      3,
+      CommandLane.Subagent,
+      3,
+    );
+    expect(queueMocks.setCommandLaneConcurrency).toHaveBeenNthCalledWith(4, CommandLane.Nested, 6);
+  });
+});

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -1,4 +1,8 @@
-import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveNestedAgentMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "../config/agent-limits.js";
 import type { loadConfig } from "../config/config.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
@@ -7,4 +11,5 @@ export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) 
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Nested, resolveNestedAgentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   performGatewaySessionReset: vi.fn(),
   getSubagentRunByChildSessionKey: vi.fn(),
   replaceSubagentRunAfterSteer: vi.fn(),
+  getChannelPlugin: vi.fn(),
   loadConfigReturn: {} as Record<string, unknown>,
 }));
 
@@ -60,6 +61,19 @@ vi.mock("../../config/config.js", async () => {
 vi.mock("../../agents/agent-scope.js", () => ({
   listAgentIds: () => ["main"],
 }));
+
+vi.mock("../../channels/plugins/registry.js", async () => {
+  const actual = await vi.importActual<typeof import("../../channels/plugins/registry.js")>(
+    "../../channels/plugins/registry.js",
+  );
+  return {
+    ...actual,
+    getChannelPlugin: (id: string) => {
+      const mocked = mocks.getChannelPlugin(id);
+      return mocked === undefined ? actual.getChannelPlugin(id as never) : mocked;
+    },
+  };
+});
 
 vi.mock("../../infra/agent-events.js", () => ({
   registerAgentRunContext: mocks.registerAgentRunContext,
@@ -155,6 +169,17 @@ function buildExistingMainStoreEntry(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+const webchatOutboundTestPlugin = {
+  id: "webchat",
+  outbound: {
+    deliveryMode: "direct",
+    resolveTarget: ({ to }: { to?: string }) => ({
+      ok: true as const,
+      to: to?.trim() || "webchat",
+    }),
+  },
+};
 
 async function runMainAgentAndCaptureEntry(idempotencyKey: string) {
   const getCapturedEntry = captureUpdatedMainEntry();
@@ -631,6 +656,73 @@ describe("gateway agent handler", () => {
     await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
     const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     expect(callArgs.bestEffortDeliver).toBe(false);
+  });
+
+  it("allows explicit webchat replyChannel delivery without an explicit target", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    mocks.getChannelPlugin.mockImplementation((id: string) =>
+      id === "webchat" ? webchatOutboundTestPlugin : undefined,
+    );
+
+    await invokeAgent(
+      {
+        message: "deliver to webchat",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        replyChannel: "webchat",
+        idempotencyKey: "test-webchat-delivery-explicit",
+      },
+      { reqId: "webchat-delivery-explicit-1" },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      deliver?: boolean;
+    };
+    expect(callArgs.channel).toBe("webchat");
+    expect(callArgs.deliver).toBe(true);
+  });
+
+  it("keeps implicit main-session delivery on webchat when that is the stored last channel", async () => {
+    mocks.getChannelPlugin.mockImplementation((id: string) =>
+      id === "webchat" ? webchatOutboundTestPlugin : undefined,
+    );
+    mockMainSessionEntry({
+      sessionId: "existing-session-id",
+      lastChannel: "webchat",
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": buildExistingMainStoreEntry({
+          lastChannel: "webchat",
+        }),
+      };
+      return await updater(store);
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "announce back to webchat",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        idempotencyKey: "test-webchat-delivery-implicit",
+      },
+      { reqId: "webchat-delivery-implicit-1" },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      deliver?: boolean;
+    };
+    expect(callArgs.channel).toBe("webchat");
+    expect(callArgs.deliver).toBe(true);
   });
 
   it("rejects public spawned-run metadata fields", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -6,6 +6,7 @@ import {
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
+import { getChannelPlugin } from "../../channels/plugins/registry.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -78,6 +79,13 @@ function resolveAllowModelOverrideFromClient(
   client: GatewayRequestHandlerOptions["client"],
 ): boolean {
   return resolveSenderIsOwnerFromClient(client) || client?.internal?.allowModelOverride === true;
+}
+
+function canDeliverGatewayInternalChannel(channel?: string | null): boolean {
+  return (
+    normalizeMessageChannel(channel) === INTERNAL_MESSAGE_CHANNEL &&
+    Boolean(getChannelPlugin(INTERNAL_MESSAGE_CHANNEL)?.outbound)
+  );
 }
 
 async function runSessionResetFromAgent(params: {
@@ -590,7 +598,8 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedTo = deliveryPlan.resolvedTo;
     let effectivePlan = deliveryPlan;
 
-    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
+    let canDeliverInternally = canDeliverGatewayInternalChannel(resolvedChannel);
+    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !canDeliverInternally) {
       const cfgResolved = cfgForAgent ?? cfg;
       try {
         const selection = await resolveMessageChannelSelection({ cfg: cfgResolved });
@@ -606,9 +615,10 @@ export const agentHandlers: GatewayRequestHandlers = {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
         return;
       }
+      canDeliverInternally = canDeliverGatewayInternalChannel(resolvedChannel);
     }
 
-    if (!resolvedTo && isDeliverableMessageChannel(resolvedChannel)) {
+    if (!resolvedTo && (isDeliverableMessageChannel(resolvedChannel) || canDeliverInternally)) {
       const cfgResolved = cfgForAgent ?? cfg;
       const fallback = resolveAgentOutboundTarget({
         cfg: cfgResolved,
@@ -621,7 +631,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
+    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !canDeliverInternally) {
       respond(
         false,
         undefined,
@@ -644,7 +654,9 @@ export const agentHandlers: GatewayRequestHandlers = {
         ? INTERNAL_MESSAGE_CHANNEL
         : resolvedChannel);
 
-    const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
+    const deliver =
+      request.deliver === true &&
+      (resolvedChannel !== INTERNAL_MESSAGE_CHANNEL || canDeliverInternally);
 
     const accepted = {
       runId,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,7 +1,11 @@
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
-import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveNestedAgentMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "../config/agent-limits.js";
 import { isRestartEnabled } from "../config/commands.js";
 import type { loadConfig } from "../config/config.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
@@ -151,6 +155,7 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
+    setCommandLaneConcurrency(CommandLane.Nested, resolveNestedAgentMaxConcurrent(nextConfig));
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);


### PR DESCRIPTION
## Summary
- allow the gateway `agent` handler to keep `webchat` as a valid delivery channel when the webchat outbound plugin is available
- stop forcing internal webchat delivery through external-channel selection / invalid-request rejection
- add regression tests for explicit `replyChannel: \"webchat\"` and implicit main-session delivery when the stored last channel is webchat

## Why
Issue #28 root-cause investigation found the main functional break in `src/gateway/server-methods/agent.ts`:
- the gateway treated `webchat` (`INTERNAL_MESSAGE_CHANNEL`) as non-deliverable
- that could suppress proactive / announce delivery before the lower outbound layer ever got a chance to broadcast to connected webchat clients

This is the primary code-path fix. The separate `sessions.list` hammering and stale `pages` MCP crash-loop are still being tracked as distinct causes/noise in #28.

## Testing
- `pnpm vitest run src/gateway/server-methods/agent.test.ts`
- `pnpm vitest run src/gateway/server-methods/agent.test.ts src/infra/outbound/agent-delivery.test.ts src/infra/outbound/targets.test.ts`
