### PR TITLE
fix(gateway): keep proactive webchat agent delivery on webchat

### DIFF
--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -2,12 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 
 const mocks = vi.hoisted(() => ({
   deliverOutboundPayloads: vi.fn(async () => []),
-  getChannelPlugin: vi.fn(() => ({})),
-  resolveOutboundTarget: vi.fn(() => ({ ok: true as const, to: "+15551234567" })),
+  getChannelPlugin: vi.fn((_channel?: string) => ({})),
+  resolveOutboundTarget: vi.fn((params?: { channel?: string; to?: string }) => ({
+    ok: true as const,
+    to: params?.channel === "webchat" ? params?.to?.trim() || "webchat" : "+15551234567",
+  })),
 }));
 
 vi.mock("../channels/plugins/index.js", () => ({
@@ -73,8 +78,22 @@ describe("deliverAgentCommandResult", () => {
   }
 
   beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
     mocks.deliverOutboundPayloads.mockClear();
-    mocks.resolveOutboundTarget.mockClear();
+    mocks.resolveOutboundTarget.mockReset();
+    mocks.resolveOutboundTarget.mockImplementation(
+      (params?: { channel?: string; to?: string }) => ({
+        ok: true as const,
+        to:
+          params?.channel === "webchat"
+            ? typeof params.to === "string" && params.to.trim()
+              ? params.to.trim()
+              : "webchat"
+            : "+15551234567",
+      }),
+    );
+    mocks.getChannelPlugin.mockReset();
+    mocks.getChannelPlugin.mockImplementation(() => ({}));
   });
 
   it("prefers explicit accountId for outbound delivery", async () => {
@@ -257,6 +276,45 @@ describe("deliverAgentCommandResult", () => {
           agentId: "exec",
         }),
       }),
+    );
+  });
+
+  it("delivers proactive webchat payloads without an explicit target when the webchat plugin is active", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "webchat",
+          plugin: createOutboundTestPlugin({
+            id: "webchat",
+            outbound: {
+              deliveryMode: "direct",
+              resolveTarget: ({ to }) => ({ ok: true, to: to?.trim() || "webchat" }),
+            },
+          }),
+          source: "test",
+        },
+      ]),
+    );
+    mocks.getChannelPlugin.mockImplementation((channel: string) =>
+      channel === "webchat" ? ({ outbound: {} } as { outbound: object }) : ({} as object),
+    );
+
+    await runDelivery({
+      opts: {
+        message: "hello",
+        deliver: true,
+        channel: "webchat",
+      },
+      sessionEntry: {
+        channel: "webchat",
+      } as SessionEntry,
+    });
+
+    expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "webchat", to: undefined }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "webchat", to: "webchat" }),
     );
   });
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -806,6 +806,41 @@ describe("gateway agent handler", () => {
     expect(respond.mock.calls[0]?.[0]).toBe(true);
   });
 
+  it("still resolves an external delivery channel when webchat is registered but no webchat route was requested", async () => {
+    mockMainSessionEntry({
+      sessionId: "existing-session-id",
+    });
+    mocks.resolveMessageChannelSelection.mockResolvedValue({ channel: "telegram" });
+    mocks.getChannelPlugin.mockImplementation((id: string) =>
+      id === "webchat" ? ({ outbound: {} } as { outbound: object }) : undefined,
+    );
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "unresolved delivery should not broadcast to webchat",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        idempotencyKey: "test-unresolved-delivery-selects-external-channel",
+      },
+      {
+        reqId: "unresolved-delivery-1",
+      },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    expect(mocks.resolveMessageChannelSelection).toHaveBeenCalledTimes(1);
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      deliver?: boolean;
+    };
+    expect(callArgs.channel).toBe("telegram");
+    expect(callArgs.deliver).toBe(true);
+  });
+
   it("handles missing cliSessionIds gracefully", async () => {
     mockMainSessionEntry({});
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   performGatewaySessionReset: vi.fn(),
   getSubagentRunByChildSessionKey: vi.fn(),
   replaceSubagentRunAfterSteer: vi.fn(),
+  resolveMessageChannelSelection: vi.fn(),
+  getChannelPlugin: vi.fn(),
   loadConfigReturn: {} as Record<string, unknown>,
 }));
 
@@ -65,6 +67,26 @@ vi.mock("../../infra/agent-events.js", () => ({
   registerAgentRunContext: mocks.registerAgentRunContext,
   onAgentEvent: vi.fn(),
 }));
+
+vi.mock("../../infra/outbound/channel-selection.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/outbound/channel-selection.js")>(
+    "../../infra/outbound/channel-selection.js",
+  );
+  return {
+    ...actual,
+    resolveMessageChannelSelection: mocks.resolveMessageChannelSelection,
+  };
+});
+
+vi.mock("../../channels/plugins/registry.js", async () => {
+  const actual = await vi.importActual<typeof import("../../channels/plugins/registry.js")>(
+    "../../channels/plugins/registry.js",
+  );
+  return {
+    ...actual,
+    getChannelPlugin: mocks.getChannelPlugin,
+  };
+});
 
 vi.mock("../../agents/subagent-registry.js", () => ({
   getSubagentRunByChildSessionKey: mocks.getSubagentRunByChildSessionKey,
@@ -735,6 +757,53 @@ describe("gateway agent handler", () => {
     expect(callArgs.channel).toBe("telegram");
     expect(callArgs.messageChannel).toBe("webchat");
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
+  });
+
+  it("accepts webchat proactive delivery when the webchat plugin is registered", async () => {
+    mockMainSessionEntry({
+      sessionId: "existing-session-id",
+      channel: "webchat",
+      accountId: "default",
+      origin: { provider: "webchat", surface: "webchat", chatType: "direct" },
+    });
+    mocks.resolveMessageChannelSelection.mockRejectedValue(
+      new Error("Channel is required (no configured channels detected)"),
+    );
+    mocks.getChannelPlugin.mockImplementation((id: string) =>
+      id === "webchat" ? ({ outbound: {} } as { outbound: object }) : undefined,
+    );
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    const respond = vi.fn();
+    await invokeAgent(
+      {
+        message: "proactive webchat delivery",
+        sessionKey: "agent:main:main",
+        channel: "webchat",
+        accountId: "default",
+        deliver: true,
+        idempotencyKey: "test-webchat-proactive-delivery",
+      },
+      {
+        respond,
+        reqId: "webchat-proactive-1",
+      },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      accountId?: string;
+      deliver?: boolean;
+    };
+    expect(callArgs.channel).toBe("webchat");
+    expect(callArgs.accountId).toBe("default");
+    expect(callArgs.deliver).toBe(true);
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
   });
 
   it("handles missing cliSessionIds gracefully", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -593,8 +593,23 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const isWebchatDeliverable = () =>
       Boolean(getChannelPlugin(INTERNAL_MESSAGE_CHANNEL)?.outbound);
+    const hasConcreteWebchatDeliveryHint = [
+      request.replyChannel,
+      request.channel,
+      sessionEntry?.deliveryContext?.channel,
+      sessionEntry?.lastChannel,
+      sessionEntry?.channel,
+      deliveryPlan.baseDelivery.channel,
+      deliveryPlan.baseDelivery.lastChannel,
+    ].some((value) => normalizeMessageChannel(value) === INTERNAL_MESSAGE_CHANNEL);
+    const canDeliverResolvedWebchat = () =>
+      isWebchatDeliverable() && hasConcreteWebchatDeliveryHint;
 
-    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !isWebchatDeliverable()) {
+    if (
+      wantsDelivery &&
+      resolvedChannel === INTERNAL_MESSAGE_CHANNEL &&
+      !canDeliverResolvedWebchat()
+    ) {
       const cfgResolved = cfgForAgent ?? cfg;
       try {
         const selection = await resolveMessageChannelSelection({ cfg: cfgResolved });
@@ -625,7 +640,11 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !isWebchatDeliverable()) {
+    if (
+      wantsDelivery &&
+      resolvedChannel === INTERNAL_MESSAGE_CHANNEL &&
+      !canDeliverResolvedWebchat()
+    ) {
       respond(
         false,
         undefined,
@@ -650,7 +669,7 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const deliver =
       request.deliver === true &&
-      (resolvedChannel !== INTERNAL_MESSAGE_CHANNEL || isWebchatDeliverable());
+      (resolvedChannel !== INTERNAL_MESSAGE_CHANNEL || canDeliverResolvedWebchat());
 
     const accepted = {
       runId,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -6,6 +6,7 @@ import {
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
+import { getChannelPlugin } from "../../channels/plugins/registry.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -590,7 +591,10 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedTo = deliveryPlan.resolvedTo;
     let effectivePlan = deliveryPlan;
 
-    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
+    const isWebchatDeliverable = () =>
+      Boolean(getChannelPlugin(INTERNAL_MESSAGE_CHANNEL)?.outbound);
+
+    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !isWebchatDeliverable()) {
       const cfgResolved = cfgForAgent ?? cfg;
       try {
         const selection = await resolveMessageChannelSelection({ cfg: cfgResolved });
@@ -621,7 +625,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
+    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !isWebchatDeliverable()) {
       respond(
         false,
         undefined,
@@ -644,7 +648,9 @@ export const agentHandlers: GatewayRequestHandlers = {
         ? INTERNAL_MESSAGE_CHANNEL
         : resolvedChannel);
 
-    const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
+    const deliver =
+      request.deliver === true &&
+      (resolvedChannel !== INTERNAL_MESSAGE_CHANNEL || isWebchatDeliverable());
 
     const accepted = {
       runId,


### PR DESCRIPTION
## Summary
- treat built-in `webchat` as a deliverable channel in the gateway `agent` RPC path instead of falling back to configured external channels
- keep `deliver=true` for proactive/background agent runs when the `webchat` outbound plugin is active
- add regression coverage for proactive `webchat` delivery in both the gateway handler and agent delivery tests

Fixes #21.

## Verification
- `pnpm vitest run src/commands/agent.delivery.test.ts`
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server-methods/agent.test.ts`
- `pnpm run build`
